### PR TITLE
Change http to https for ALBERS references

### DIFF
--- a/src/routes/data/index.svelte
+++ b/src/routes/data/index.svelte
@@ -164,7 +164,7 @@
         <Button
           kind="tertiary"
           icon="{ArrowRight16}"
-          href="http://albers.cnr.berkeley.edu/data/"
+          href="https://albers.cnr.berkeley.edu/data/"
           >Cal-Adapt Data Server</Button
         >
       </p>

--- a/src/routes/tools/extreme-weather/index.svelte
+++ b/src/routes/tools/extreme-weather/index.svelte
@@ -427,7 +427,7 @@
             <ul class="source-list">
               <li class="source-list-item">
                 <a
-                  href="http://albers.cnr.berkeley.edu/data/hadisd/"
+                  href="https://albers.cnr.berkeley.edu/data/hadisd/"
                   target="_blank"
                   >Hourly Observed Historical Data Product (csv)</a
                 >
@@ -445,7 +445,7 @@
               <li class="source-list-item">
                 Explanatory Guide to Hourly Observed Historical Data on
                 Cal-Adapt (<a
-                  href="http://albers.cnr.berkeley.edu/data/hadisd/user_guide_to_hourly_data.pdf"
+                  href="https://albers.cnr.berkeley.edu/data/hadisd/user_guide_to_hourly_data.pdf"
                   target="_blank">link</a
                 >)
               </li>


### PR DESCRIPTION
This PR changes the URLs in the Svelte files for data and tools from http to https for ALBERS data server references.