### PR TITLE
Launch tutorial videos in new tab

### DIFF
--- a/src/routes/help/_ItemsList.svelte
+++ b/src/routes/help/_ItemsList.svelte
@@ -37,6 +37,7 @@
                   style="font-size:1rem;"
                   href="{item.metadata.video}"
                   rel="prefetch"
+                  target="_blank"
                 >
                   {item.metadata.title}
                 </a>


### PR DESCRIPTION
Added extra target prop to Tutorial video links. This works for now but if we change structure of this page we'll have to change all this.