### PR TITLE
Added order tag to FAQs so that categories can be sorted

### DIFF
--- a/content/faqs/can-i-get-data-for-my-aoi.md
+++ b/content/faqs/can-i-get-data-for-my-aoi.md
@@ -2,6 +2,7 @@
 title: Can I get data for my specific project area?
 tags: data
 category: getting-data
+order: 3
 ---
 
 You can upload your own file with a feature for spatial aggregation. Cal-Adapt supports zipped shapefiles, GeoJSON, KML, and WKT with one feature (point, line, or polygon) per file. If a file has multiple features, data will be returned for the full geographic extent of the file. The maximum supported area is 20,000 square miles.

--- a/content/faqs/can-i-make-suggestions-for-additional-data.md
+++ b/content/faqs/can-i-make-suggestions-for-additional-data.md
@@ -2,6 +2,7 @@
 title: Can I make suggestions for additional data?
 tags: data, help
 category: getting-data
+order: 7
 ---
 
 Yes! We welcome suggestions for additional data at <support@cal-adapt.org>. Please note that data must be published using a peer review process.

--- a/content/faqs/how-are-netcdf-files-structured.md
+++ b/content/faqs/how-are-netcdf-files-structured.md
@@ -2,6 +2,7 @@
 title: How are NetCDF files structured?
 tags: data
 category: getting-data
+order: 6
 ---
 
 NetCDF files are self-describing by design. Information about the dimensions and variables stored in the NetCDF file are readable by software tools. Contact and processing history are also generally stored as metadata in the NetCDF header and can be read by software like GDAL, NCO, CDO, QGIS, and ArcGIS.

--- a/content/faqs/how-can-i-download-boundary-layers.md
+++ b/content/faqs/how-can-i-download-boundary-layers.md
@@ -2,6 +2,7 @@
 title: How can I download boundary layers?
 tags: data
 category: getting-data
+order: 2
 ---
 
 The following boundary layers can be downloaded from the Cal-Adapt API in GeoJSON format:

--- a/content/faqs/how-can-i-download-data-from-caladapt.md
+++ b/content/faqs/how-can-i-download-data-from-caladapt.md
@@ -2,6 +2,7 @@
 title: How can I download data from Cal-Adapt?
 tags: data
 category: getting-data
+order: 1
 ---
 
 There are many ways to download data from Cal-Adapt:

--- a/content/faqs/how-can-i-get-help.md
+++ b/content/faqs/how-can-i-get-help.md
@@ -2,6 +2,7 @@
 title: How can I get help?
 tags: help
 category: getting-help
+order: 2
 ---
 
 All of Cal-Adapt’s climate tools include “Learn More” links that provide explanations and more information about tool parameters and terminology.

--- a/content/faqs/how-can-i-learn-more-about-climate-change-and-climate-data.md
+++ b/content/faqs/how-can-i-learn-more-about-climate-change-and-climate-data.md
@@ -2,6 +2,7 @@
 title: How can I learn more about climate change and climate data?
 tags: data, help
 category: understanding-data
+order: 1
 ---
 
 Cal-Adapt has a [Getting Started](/help/get-started/) page where you can learn about climate change, climate data, and Cal-Adapt.

--- a/content/faqs/how-can-i-provide-feedback.md
+++ b/content/faqs/how-can-i-provide-feedback.md
@@ -2,6 +2,7 @@
 title: How can I provide feedback?
 tags: about, help
 category: about-caladapt
+order: 6
 ---
 
 The Cal-Adapt team always values feedback. To provide feedback on interactive visualizations, data-download tools, and other features available on Cal-Adapt org, or to let us know about how you have used Cal-Adapt, please email <support@cal-adapt.org>.

--- a/content/faqs/how-do-i-cite-caladapt.md
+++ b/content/faqs/how-do-i-cite-caladapt.md
@@ -2,6 +2,7 @@
 title: How do I cite Cal-Adapt?
 tags: about, other
 category: about-caladapt
+order: 5
 ---
 
 **Citing information and visualizations (maps, charts, screenshots, etc.) available via Cal-Adapt:**

--- a/content/faqs/how-do-i-report-an-error.md
+++ b/content/faqs/how-do-i-report-an-error.md
@@ -2,6 +2,7 @@
 title: How do I report an error?
 tags: help
 category: getting-help
+order: 3
 ---
 
 The Cal-Adapt team appreciates it when users report errors. To report an error, please email <support@cal-adapt.org>. Please include your browser details using a service like [What’s My Browser?](https://www.whatsmybrowser.org/) and share a screenshot of your issue when possible. This helps us troubleshoot issues faster. Thank you in advance!

--- a/content/faqs/how-do-i-use-the-api-to-get-data.md
+++ b/content/faqs/how-do-i-use-the-api-to-get-data.md
@@ -2,6 +2,7 @@
 title: How do I use the API to get data?
 tags: data
 category: getting-data
+order: 5
 ---
 
 [Here is an overview](https://berkeley-gif.github.io/caladapt-docs/) of Cal-Adapt’s RESTful API and documentation on how to use the API. If you have additional questions, you can email us at <support@cal-adapt.org>.

--- a/content/faqs/how-do-i-work-with-variability-in-climate-change-projections.md
+++ b/content/faqs/how-do-i-work-with-variability-in-climate-change-projections.md
@@ -2,6 +2,7 @@
 title: How do I work with variability in climate change projections?
 tags: data
 category: understanding-data
+order: 6
 ---
 
 Variability is a natural part of our climate systems and will not cease under climate change. Our climate in California has always been variable; for example, some years are wetter than other years, and some years see more wildfire than other years. Projections show that climate change will cause increases in average summer temperatures, but not every year looks like the average year.

--- a/content/faqs/how-do-you-decide-what-tool-to-build.md
+++ b/content/faqs/how-do-you-decide-what-tool-to-build.md
@@ -2,6 +2,7 @@
 title: How do you decide what tool to build?
 tags: tools
 category: about-caladapt
+order: 4
 ---
 
 The interactive visualizations and easily accessible data currently available on Cal-Adapt reflect priorities articulated by users and the funding agencies who have provided support for making climate data accessible. Cal-Adapt’s users are frequently consulted and engaged in beta-testing processes to evaluate website and tool prototypes. We are grateful to those who have provided refinements to developed tools and shared ideas to ensure that what is built is as useful as it can be. 

--- a/content/faqs/how-often-is-caladapt-updated.md
+++ b/content/faqs/how-often-is-caladapt-updated.md
@@ -2,6 +2,7 @@
 title: How often is Cal-Adapt updated?
 tags: about
 category: about-caladapt
+order: 2
 ---
 
 Cal-Adapt is updated as new climate change research products become available and complete the peer-review process, with an emphasis on providing access to climate data that are foundational to the State of California’s climate change assessments and other climate-related products of CEC’s energy-related environmental research program.

--- a/content/faqs/what-baseline-time-period-should-i-use-to-compare-future-climate-projections.md
+++ b/content/faqs/what-baseline-time-period-should-i-use-to-compare-future-climate-projections.md
@@ -2,6 +2,7 @@
 title: What baseline time period should I use to compare future climate projections?
 tags: data, other
 category: understanding-data
+order: 3
 ---
 
 Cal-Adapt typically represents the historical baseline as a thirty-year window from 1961 to 1990. In this period, most of California’s critical infrastructure was developed and the first signals of anthropogenic climate change were beginning to be felt. We also have observed and modeled climate data for this period. 1986 to 2005 is another common baseline period.

--- a/content/faqs/what-climate-models-should-i-use-in-my-analysis-what-are-the-priority-models.md
+++ b/content/faqs/what-climate-models-should-i-use-in-my-analysis-what-are-the-priority-models.md
@@ -2,6 +2,7 @@
 title: What climate models should I use in my analysis? What are the priority models?
 tags: data
 category: understanding-data
+order: 2
 ---
 
 Thirty-two global climate model (GCM) simulations produced by institutions across the world served as a basis for California’s climate projections for California’s Fourth Climate Change Assessment, and thus for much of the data currently available on Cal-Adapt. These 32 GCMs are from the Coupled Model Intercomparison Project, version 5 (CMIP5).

--- a/content/faqs/what-time-period-should-i-select-for-my-analysis.md
+++ b/content/faqs/what-time-period-should-i-select-for-my-analysis.md
@@ -2,6 +2,7 @@
 title: What time period should I select for my analysis?
 tags: data
 category: understanding-data
+order: 4
 ---
 
 The specific time period you select will depend on the purpose of your analysis. However, regardless of the time period you select, we recommend that you abide by a few principles:

--- a/content/faqs/what-tool-should-i-use.md
+++ b/content/faqs/what-tool-should-i-use.md
@@ -2,6 +2,7 @@
 title: What tool should I use?
 tags: tools
 category: tools-caladapt
+order: 2
 ---
 
 The tool that you use will depend on the general climate variable you are interested in (e.g., temperature, precipitation, or sea level rise) and the level of detail or customization you would like in interfacing with the climate projections. If you are new to Cal-Adapt or don’t know where to start, we recommend you first visit the Local Climate Change Snapshot Tool. The Local Climate Change Snapshot Tool is designed to be straightforward and accessible for most users. If you would like an introduction to the tool, you can watch [this short video](https://www.youtube.com/watch?v=qcXtv2LpWr0).

--- a/content/faqs/what-web-browsers-are-supported.md
+++ b/content/faqs/what-web-browsers-are-supported.md
@@ -2,6 +2,7 @@
 title: What web browsers are supported?
 tags: help
 category: getting-help
+order: 1
 ---
 
 We support recent versions of popular web browsers like Google Chrome, Mozilla Firefox, Apple Safari, and Microsoft Edge. In accordance with Microsoft’s official retirement of Internet Explorer 11, we no longer support Internet Explorer 11. Any browser you use needs to have JavaScript turned on to use Cal-Adapt’s Climate Tools.

--- a/content/faqs/where-does-caladapt-data-come-from.md
+++ b/content/faqs/where-does-caladapt-data-come-from.md
@@ -2,6 +2,7 @@
 title: Where does Cal-Adapt’s data come from?
 tags: data, about
 category: about-caladapt
+order: 1
 ---
 
 Data on Cal-Adapt include climate projections developed with funding from the California Energy Commission’s energy-related environmental research program, as well as other climate and weather data germane to California. These data are the products of peer-reviewed science and quality-controlled data collection efforts. Data sources and related publications are listed, described, and linked at the bottom of each tool. Much of the data currently on Cal-Adapt was generated in [California’s Fourth Climate Change Assessment](https://www.climateassessment.ca.gov/).

--- a/content/faqs/which-rcp-scenarios-should-i-use-in-my-analysis.md
+++ b/content/faqs/which-rcp-scenarios-should-i-use-in-my-analysis.md
@@ -2,6 +2,7 @@
 title: Which RCP (emissions) scenarios should I use in my analysis?
 tags: data
 category: understanding-data
+order: 5
 ---
 
 Representative concentration pathways (RCP) portray possible future greenhouse gas and aerosol emissions scenarios. RCP scenarios are not specific policies, demographics, or economic futures; instead, they are defined by total solar radiative forcing by 2100. To address uncertainty in future concentrations of greenhouse gases and emissions of aerosols, data made available via Cal-Adapt incorporates two RCPs: RCP 4.5 and RCP 8.5.

--- a/content/faqs/who-is-caladapt-audience.md
+++ b/content/faqs/who-is-caladapt-audience.md
@@ -2,6 +2,7 @@
 title: Who is Cal-Adapt’s audience?
 tags: about
 category: about-caladapt
+order: 3
 ---
 
 CEC originally funded the development of Cal-Adapt to serve energy-sector users. More recent support from the Strategic Growth Council (SGC) supports a broader user base that includes local governments and others who are engaged in climate change analysis, mitigation, and adaptation. The interactive visualizations and easily accessible data currently available on Cal-Adapt have also been used by academic scientists and professionals working in sectors like forestry, watershed and water resource management, agriculture, and public health. Additionally, Cal-Adapt can support climate change education in community, school and university settings. 

--- a/content/faqs/why-do-caladapt-tools-default-to-certain-time-periods.md
+++ b/content/faqs/why-do-caladapt-tools-default-to-certain-time-periods.md
@@ -2,6 +2,7 @@
 title: Why do Cal-Adapt tools default to certain time periods?
 tags: tools
 category: tools-caladapt
+order: 1
 ---
 
 Cal-Adapt tools typically display statistics for thirty-year periods. Thirty years is the traditional length of record used in climatological studies and is known as a climatological normal. Thirty years is considered the minimum number of years needed to characterize a regional climate and apply statistical tests. This aligns with best practice in climate science since climate is the long-term trend in prevailing weather conditions. Looking at a climate projection for any one year, or even a few years, is likely to be misleading for adaptation planning because variability is inherent to climate systems and longer-term trends cannot be determined based on a single year’s data. The thirty-year periods in Cal-Adapt capture typical adaptation planning horizons and align with those used in [California’s Fourth Climate Change Assessment](https://www.climateassessment.ca.gov/).

--- a/content/faqs/why-does-caladapt-show-data-only-for-ca.md
+++ b/content/faqs/why-does-caladapt-show-data-only-for-ca.md
@@ -2,6 +2,7 @@
 title: Why does Cal-Adapt show data only for California?
 tags: data
 category: getting-data
+order: 4
 ---
 
 Cal-Adapt is built predominantly for California users so the site is able to respond to specific needs in California. Similar resources exist in other states, and several climate change datasets and tools are hosted by federal agencies.

--- a/content/faqs/why-does-the-wildfire-tool-not-show-data-for-my-location.md
+++ b/content/faqs/why-does-the-wildfire-tool-not-show-data-for-my-location.md
@@ -2,6 +2,7 @@
 title: Why does the wildfire tool not show data for my location?
 tags: tools
 category: tools-caladapt
+order: 3
 ---
 
 The modeled wildfire projections on Cal-Adapt were only generated for locations falling under state and federal fire protection responsibility. For more information on how these wildfire projections were generated, please review [Westerling et al. 2018](https://www.energy.ca.gov/sites/default/files/2019-11/Projections_CCCA4-CEC-2018-014_ADA.pdf).


### PR DESCRIPTION
I have added an order tag 1..n for each category so that FAQs can be ordered as they appear in the FAQ word document. The category functionality needs to be added to the FAQs still.