### PR TITLE
Home page cards style update

### DIFF
--- a/src/components/cards/Card.svelte
+++ b/src/components/cards/Card.svelte
@@ -18,6 +18,7 @@
   export let iconPaths = [];
   export let textColor = null;
   export let bgColor = null;
+  export let useGradient = false;
   export let useRule = false;
 
   $: isVariant = Boolean(
@@ -27,6 +28,10 @@
   );
   $: varCardHeight =
     height && typeof height === "number" ? `${height}rem` : CARD_DEFAULT_HEIGHT;
+
+  $: background = useGradient
+    ? "linear-gradient(180deg, var(--card-bg-color) 50%, var(--gray-70) 100%)"
+    : "var(--card-bg-color, var(--white))";
 </script>
 
 <style lang="scss">
@@ -36,7 +41,6 @@
     height: var(--card-height, auto);
     box-sizing: border-box;
     position: relative;
-    background-color: var(--card-bg-color, var(--white));
     border: 1px solid var(--gray-20);
 
     // a11y fix for Safari
@@ -55,7 +59,7 @@
 
 <li
   class="shadow lift"
-  style="--card-height:{varCardHeight};--text-color:{textColor}; --card-bg-color:{bgColor}"
+  style="--card-height:{varCardHeight};--text-color:{textColor}; --card-bg-color:{bgColor}; background:{background};"
 >
   {#if imgSrc}
     <CardImage imgSrc="{imgSrc}" />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -156,6 +156,7 @@
               textColor: "white",
               bgColor: cardBgColors[index],
               useRule: true,
+              useGradient: true,
             }}
           />
         {/each}


### PR DESCRIPTION
Adds a gradient to the background fill color of the cards on the homepage to spruce them up a bit:

<img width="1641" alt="Screen Shot 2021-09-24 at 4 36 02 PM" src="https://user-images.githubusercontent.com/161748/134949241-5806213b-0eb2-4d0c-b11a-eee9c5a44766.png">


