### PR TITLE
Update github action to use npm build script

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,4 +22,4 @@ jobs:
         node-version: 14.17
         cache: 'npm'
     - run: npm ci
-    - run: npm run export --if-present
+    - run: npm run build --if-present


### PR DESCRIPTION
@mukhtyar @elehmer I'm updating the Github Action to run `build` instead of `export` as it will help reduce the amount of time the workflow will take. I suspect there are very rare circumstances where the app would build successfully but the exporting of static files would fail so we probably don't need to run the `export` command as a check on each PR.