### PR TITLE
Use sapper:prefetch on internal links

### DIFF
--- a/src/components/cards/CardTitle.svelte
+++ b/src/components/cards/CardTitle.svelte
@@ -32,13 +32,13 @@
 </style>
 
 {#if headingLevel === 3}
-  <h3><a href="{linkPath}">{titleText}</a></h3>
+  <h3><a sapper:prefetch href="{linkPath}">{titleText}</a></h3>
 {:else if headingLevel === 4}
-  <h4><a href="{linkPath}">{titleText}</a></h4>
+  <h4><a sapper:prefetch href="{linkPath}">{titleText}</a></h4>
 {:else if headingLevel === 5}
-  <h5><a href="{linkPath}">{titleText}</a></h5>
+  <h5><a sapper:prefetch href="{linkPath}">{titleText}</a></h5>
 {:else if headingLevel === 6}
-  <h6><a href="{linkPath}">{titleText}</a></h6>
+  <h6><a sapper:prefetch href="{linkPath}">{titleText}</a></h6>
 {:else}
-  <h2><a href="{linkPath}">{titleText}</a></h2>
+  <h2><a sapper:prefetch href="{linkPath}">{titleText}</a></h2>
 {/if}

--- a/src/partials/EventStub.svelte
+++ b/src/partials/EventStub.svelte
@@ -44,6 +44,7 @@
     rel="prefetch"
     href="blog/{event.slug}/"
     title="Read more"
+    sapper:prefetch
   >
     <div class="card-img">
       <img src="/img/blog/{event.metadata.image}" alt="..." />

--- a/src/partials/Nav.svelte
+++ b/src/partials/Nav.svelte
@@ -6,6 +6,7 @@
 
 <header aria-label="Cal-Adapt Home" class="main-nav bx--header" role="banner">
   <a
+    sapper:prefetch
     class="bx--header__name"
     aria-current="{segment === undefined ? 'page' : undefined}"
     href="/"
@@ -42,6 +43,7 @@
     <ul aria-label="Cal-Adapt" class="bx--header__menu-bar" role="menubar">
       <li>
         <a
+          sapper:prefetch
           href="/tools/"
           class="bx--header__menu-item"
           role="menuitem"
@@ -53,6 +55,7 @@
       </li>
       <li>
         <a
+          sapper:prefetch
           href="/data/"
           class="bx--header__menu-item"
           role="menuitem"
@@ -64,6 +67,7 @@
       </li>
       <li>
         <a
+          sapper:prefetch
           href="/help/"
           class="bx--header__menu-item"
           role="menuitem"
@@ -75,6 +79,7 @@
       </li>
       <li>
         <a
+          sapper:prefetch
           href="/blog/"
           class="bx--header__menu-item"
           role="menuitem"
@@ -86,6 +91,7 @@
       </li>
       <li>
         <a
+          sapper:prefetch
           href="/events/"
           class="bx--header__menu-item"
           role="menuitem"
@@ -98,6 +104,7 @@
 
       <li>
         <a
+          sapper:prefetch
           href="/about/"
           class="bx--header__menu-item"
           role="menuitem"

--- a/src/partials/SidebarRight.svelte
+++ b/src/partials/SidebarRight.svelte
@@ -74,7 +74,9 @@
       {#each upcomingEvents as event}
         <li class="item">
           <p class="item-title">
-            <a href="{`events/${event.slug}`}">{event.metadata.title}</a>
+            <a sapper:prefetch href="{`events/${event.slug}`}"
+              >{event.metadata.title}</a
+            >
           </p>
           <p class="item-text">{event.metadata.eventdatestring}</p>
           <p class="item-text">
@@ -84,7 +86,7 @@
       {/each}
     </ul>
     <span class="sidebar-block-link">
-      <a href="/events">See All Events</a>
+      <a sapper:prefetch href="/events">See All Events</a>
     </span>
   </div>
 {/if}
@@ -97,14 +99,16 @@
       {#each posts as post}
         <li class="item">
           <p class="item-title">
-            <a href="{`blog/${post.slug}`}">{post.metadata.title}</a>
+            <a sapper:prefetch href="{`blog/${post.slug}`}"
+              >{post.metadata.title}</a
+            >
           </p>
           <p class="item-text">{post.metadata.snippet}</p>
         </li>
       {/each}
     </ul>
     <span class="sidebar-block-link">
-      <a href="/blog">See All Posts</a>
+      <a sapper:prefetch href="/blog">See All Posts</a>
     </span>
   </div>
 {/if}
@@ -159,7 +163,9 @@
   <div class="sidebar-block">
     <ul class="page-anchor-links-list">
       {#each anchors as anchor}
-        <li><a href="{$page.path}#{anchor.href}">{anchor.text}</a></li>
+        <li>
+          <a sapper:prefetch href="{$page.path}#{anchor.href}">{anchor.text}</a>
+        </li>
       {/each}
     </ul>
   </div>

--- a/src/routes/about/index.svelte
+++ b/src/routes/about/index.svelte
@@ -265,18 +265,21 @@
           </li>
           <li>
             Designing tools and content to help users better understand climate
-            data (via tooltips, <a href="/help/glossary">Glossary</a> and
-            <a href="/blog">Cal-Adapt Blog</a>) and learn best practices for
-            working with climate projections (see our
-            <a href="/help/get-started">Get Started</a> guide). We make it easy to
-            share charts and tables of climate data with stakeholders and provide
-            options for customizing data visualizations to meet sector specific requirements
-            in some of our more technical tools.
+            data (via tooltips, <a sapper:prefetch href="/help/glossary"
+              >Glossary</a
+            >
+            and
+            <a sapper:prefetch href="/blog">Cal-Adapt Blog</a>) and learn best
+            practices for working with climate projections (see our
+            <a sapper:prefetch href="/help/get-started">Get Started</a> guide). We
+            make it easy to share charts and tables of climate data with stakeholders
+            and provide options for customizing data visualizations to meet sector
+            specific requirements in some of our more technical tools.
           </li>
           <li>
-            Building a public <a href="/data">Cal-Adapt API</a> to empower researchers
-            and developers to integrate climate data on Cal-Adapt into existing workflows
-            and develop domain specific applications.
+            Building a public <a sapper:prefetch href="/data">Cal-Adapt API</a> to
+            empower researchers and developers to integrate climate data on Cal-Adapt
+            into existing workflows and develop domain specific applications.
           </li>
           <li>
             Engaging with and learning from our users through workshops,

--- a/src/routes/blog/[slug].svelte
+++ b/src/routes/blog/[slug].svelte
@@ -136,7 +136,7 @@
             </ul>
           </div>
           <div class="back">
-            <p><a href="/blog/">Back to Cal-Adapt Blog</a></p>
+            <p><a sapper:prefetch href="/blog/">Back to Cal-Adapt Blog</a></p>
           </div>
         </div>
       </div>

--- a/src/routes/blog/_search.svelte
+++ b/src/routes/blog/_search.svelte
@@ -40,10 +40,10 @@
         <!-- Breadcrumb -->
         <ol class="breadcrumb breadcrumb-scroll">
           <li class="breadcrumb-item">
-            <a href="/" class="text-gray-700"> Home </a>
+            <a sapper:prefetch href="/" class="text-gray-700"> Home </a>
           </li>
           <li class="breadcrumb-item">
-            <a href="/blog" class="text-gray-700"> Blog </a>
+            <a sapper:prefetch href="/blog" class="text-gray-700"> Blog </a>
           </li>
           <li class="breadcrumb-item active" aria-current="page">Search</li>
         </ol>
@@ -69,7 +69,7 @@
         <ul class="list p-2">
           {#each articles as post}
             <li class="list-item d-flex">
-              <a href="blog/{post.slug}/" class="flex-grow-1">
+              <a sapper:prefetch href="blog/{post.slug}/" class="flex-grow-1">
                 {post.metadata.title}
               </a>
               <time datetime="{post.metadata.pubdate}"
@@ -82,7 +82,7 @@
         <ul class="list p-2">
           {#each webinars as post}
             <li class="list-item d-flex">
-              <a href="blog/{post.slug}/" class="flex-grow-1">
+              <a sapper:prefetch href="blog/{post.slug}/" class="flex-grow-1">
                 {post.metadata.title}
               </a>
               <time datetime="{post.metadata.pubdate}"
@@ -95,7 +95,7 @@
         <ul class="list p-2">
           {#each tutorials as post}
             <li class="list-item d-flex">
-              <a href="blog/{post.slug}/" class="flex-grow-1">
+              <a sapper:prefetch href="blog/{post.slug}/" class="flex-grow-1">
                 {post.metadata.title}
               </a>
               <time datetime="{post.metadata.pubdate}"
@@ -137,7 +137,7 @@
               Help
             </h6>
             <p class="font-size-sm">
-              Explore our collection of <a href="/help"
+              Explore our collection of <a sapper:prefetch href="/help"
                 >frequently asked questions</a
               > to learn more about using Cal-Adapt.
             </p>
@@ -160,7 +160,9 @@
               Keep up to date with new climate tools, data and resources on
               Cal-Adapt. Subscribe to the Cal-Adapt Newsletter.
             </p>
-            <a href="/signup/" class="btn btn-primary">Subscribe</a>
+            <a sapper:prefetch href="/signup/" class="btn btn-primary"
+              >Subscribe</a
+            >
           </div>
         </div>
         <!-- end Newsletter Card -->

--- a/src/routes/events/[slug].svelte
+++ b/src/routes/events/[slug].svelte
@@ -155,7 +155,7 @@
             </ul>
           </div>
           <div class="back">
-            <p><a href="/events/">Back to All Events</a></p>
+            <p><a sapper:prefetch href="/events/">Back to All Events</a></p>
           </div>
         </div>
       </div>

--- a/src/routes/events/_EventListItem.svelte
+++ b/src/routes/events/_EventListItem.svelte
@@ -92,6 +92,7 @@
     <div class="button-container">
       {#if isFutureEvent}
         <Button
+          sapper:prefetch
           href="/events/{slug}"
           kind="tertiary"
           size="field"
@@ -100,6 +101,7 @@
         >
       {:else}
         <Button
+          sapper:prefetch
           href="/events/{slug}"
           kind="tertiary"
           size="small"

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -121,8 +121,8 @@
           <div class="bx--col">
             <p class="description">
               No events are currently scheduled. Please check back later or
-              <a href="/signup/">subscribe to our newsletter</a> to be notified when
-              future events are announced.
+              <a sapper:prefetch href="/signup/">subscribe to our newsletter</a>
+              to be notified when future events are announced.
             </p>
           </div>
         </div>

--- a/src/routes/help/_ItemsList.svelte
+++ b/src/routes/help/_ItemsList.svelte
@@ -58,6 +58,7 @@
             <StructuredListRow>
               <StructuredListCell>
                 <a
+                  sapper:prefetch
                   style="font-size:1rem;"
                   href="{`/help/${slug}/${item.slug}/`}"
                   rel="prefetch"

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -137,7 +137,7 @@
         </p>
 
         <div class="btn-container">
-          <Button icon="{ArrowRight16}" href="/about"
+          <Button icon="{ArrowRight16}" href="/about" sapper:prefetch
             >More about Cal-Adapt</Button
           >
         </div>


### PR DESCRIPTION
This adds [Sapper's prefetching](https://sapper.svelte.dev/docs#sapper_prefetch) to internal links to help speed up page load. It's very noticeable when going to a tool from the tools page. 

@mukhtyar let me know if there are any internal links I may have missed. It might not be necessary to have on every internal link, probably just ones that point to JS heavy pages like the tools.