### PR TITLE
Update homepage cards gradients

### DIFF
--- a/content/homepage/cards.js
+++ b/content/homepage/cards.js
@@ -4,35 +4,41 @@ export default [
     linkPath: "/help/get-started",
     description:
       "Learn how to get started with using climate data for California.",
+    bgColor: "var(--card-gradient-01)",
   },
   {
     titleText: "Local Climate Change Snapshot Tool",
     linkPath: "/tools/local-climate-change-snapshot",
     description:
       "Quickly view a variety of climate data for a city, county, or other place.",
+      bgColor: "var(--card-gradient-02)",
   },
   {
     titleText: "Explore all Climate Tools",
     linkPath: "/tools",
     description:
       "Explore data on temperature, precipitation, snowpack, wildfire, and more.",
+    bgColor: "var(--card-gradient-03)",
   },
   {
     titleText: "Download Data",
     linkPath: "/data",
     description:
       "Download climate data in NetCDF, CSV and GeoTIFF formats for your area.",
+    bgColor: "var(--card-gradient-03)",
   },
   {
     titleText: "Tutorials & Webinars",
     linkPath: "/help/tutorials",
     description:
       "Browse our video collection of tool tutorials and past webinars.",
+    bgColor: "var(--card-gradient-02)",
   },
   {
     titleText: "Developers",
     linkPath: "/data/#cal-adapt-api",
     description:
       "Integrate climate data in your workflows with the Cal-Adapt API.",
+    bgColor: "var(--card-gradient-01)",
   },
 ];

--- a/src/components/cards/Card.svelte
+++ b/src/components/cards/Card.svelte
@@ -18,7 +18,6 @@
   export let iconPaths = [];
   export let textColor = null;
   export let bgColor = null;
-  export let useGradient = false;
   export let useRule = false;
 
   $: isVariant = Boolean(
@@ -28,10 +27,6 @@
   );
   $: varCardHeight =
     height && typeof height === "number" ? `${height}rem` : CARD_DEFAULT_HEIGHT;
-
-  $: background = useGradient
-    ? "linear-gradient(180deg, var(--card-bg-color) 50%, var(--gray-70) 100%)"
-    : "var(--card-bg-color, var(--white))";
 </script>
 
 <style lang="scss">
@@ -42,6 +37,7 @@
     box-sizing: border-box;
     position: relative;
     border: 1px solid var(--gray-20);
+    background: var(--card-bg-color, var(--white));
 
     // a11y fix for Safari
     // see: https://developer.mozilla.org/en-US/docs/Web/CSS/list-style#accessibility_concerns
@@ -59,7 +55,7 @@
 
 <li
   class="shadow lift"
-  style="--card-height:{varCardHeight};--text-color:{textColor}; --card-bg-color:{bgColor}; background:{background};"
+  style="--card-height:{varCardHeight};--text-color:{textColor}; --card-bg-color:{bgColor};"
 >
   {#if imgSrc}
     <CardImage imgSrc="{imgSrc}" />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -157,9 +157,7 @@
               height: cardHeight,
               ctaText: "Learn more",
               textColor: "white",
-              bgColor: cardBgColors[index],
               useRule: true,
-              useGradient: true,
             }}
           />
         {/each}

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -34,6 +34,20 @@ $card-bg-color-01: saturate($teal-60, 5);
 $card-bg-color-02: adjust-hue($card-bg-color-01, -15deg);
 $card-bg-color-03: adjust-hue($card-bg-color-01, 15deg);
 
+$card-gradient-01: linear-gradient(180deg, #017a4c 0%, #015946 100%);
+$card-gradient-02: linear-gradient(
+  180deg,
+  #017c7f 0%,
+  #017c7f 0.01%,
+  #014b66 100%
+);
+$card-gradient-03: linear-gradient(
+  180deg,
+  #016f99 0%,
+  #012866 100%,
+  #014980 100%
+);
+
 $caladapt-colors: (
   "gray-10": $gray-10,
   "gray-20": $gray-20,
@@ -258,6 +272,10 @@ $gcm-MIROC5: rgba(148, 103, 189, 1);
   --card-bg-color-01: #{$card-bg-color-01};
   --card-bg-color-02: #{$card-bg-color-02};
   --card-bg-color-03: #{$card-bg-color-03};
+
+  --card-gradient-01: #{$card-gradient-01};
+  --card-gradient-02: #{$card-gradient-02};
+  --card-gradient-03: #{$card-gradient-03};
 
   --interactive-01: #{$interactive-01};
   --interactive-02: #{$interactive-02};

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -30,14 +30,7 @@ $teal-80: #02484a;
 $teal-90: #013031;
 $teal-100: #001818;
 
-$card-gradient-01: linear-gradient(
-  180deg,
-  #017a4c,
-  #00724c,
-  #00694a,
-  #006149,
-  #015946
-);
+$card-gradient-01: linear-gradient(180deg, #017a38 0%, #015946 100%);
 $card-gradient-02: linear-gradient(
   180deg,
   #017c7f,

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -30,10 +30,6 @@ $teal-80: #02484a;
 $teal-90: #013031;
 $teal-100: #001818;
 
-$card-bg-color-01: saturate($teal-60, 5);
-$card-bg-color-02: adjust-hue($card-bg-color-01, -15deg);
-$card-bg-color-03: adjust-hue($card-bg-color-01, 15deg);
-
 $card-gradient-01: linear-gradient(
   180deg,
   #017a4c,
@@ -87,9 +83,6 @@ $caladapt-colors: (
   "blue-50": $blue-50,
   "blue-60": $blue-60,
   "blue-70": $blue-70,
-  "card-bg-color-01": $card-bg-color-01,
-  "card-bg-color-02": $card-bg-color-02,
-  "card-bg-color-03": $card-bg-color-03,
 );
 
 // Carbon theme colors for Cal-Adapt
@@ -279,10 +272,6 @@ $gcm-MIROC5: rgba(148, 103, 189, 1);
   --teal-80: #{$teal-80};
   --teal-90: #{$teal-90};
   --teal-100: #{$teal-100};
-
-  --card-bg-color-01: #{$card-bg-color-01};
-  --card-bg-color-02: #{$card-bg-color-02};
-  --card-bg-color-03: #{$card-bg-color-03};
 
   --card-gradient-01: #{$card-gradient-01};
   --card-gradient-02: #{$card-gradient-02};

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -30,22 +30,24 @@ $teal-80: #02484a;
 $teal-90: #013031;
 $teal-100: #001818;
 
-$card-gradient-01: linear-gradient(180deg, #017a38 0%, #015946 100%);
+$card-gradient-01: linear-gradient(
+  180deg,
+  #187a45 0%,
+  #125949 71.35%,
+  #0d4034 97.4%
+);
 $card-gradient-02: linear-gradient(
   180deg,
-  #017c7f,
-  #00707b,
-  #006376,
-  #00576f,
-  #014b66
+  #197d7f 0%,
+  #017f77 0.01%,
+  #145066 72.92%,
+  #0f3c4d 100%
 );
 $card-gradient-03: linear-gradient(
   180deg,
-  #016f99,
-  #005d8f,
-  #004c83,
-  #003a75,
-  #012866
+  #1f7799 0%,
+  #195380 76.04%,
+  #143466 100%
 );
 
 $caladapt-colors: (

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -34,18 +34,29 @@ $card-bg-color-01: saturate($teal-60, 5);
 $card-bg-color-02: adjust-hue($card-bg-color-01, -15deg);
 $card-bg-color-03: adjust-hue($card-bg-color-01, 15deg);
 
-$card-gradient-01: linear-gradient(180deg, #017a4c 0%, #015946 100%);
+$card-gradient-01: linear-gradient(
+  180deg,
+  #017a4c,
+  #00724c,
+  #00694a,
+  #006149,
+  #015946
+);
 $card-gradient-02: linear-gradient(
   180deg,
-  #017c7f 0%,
-  #017c7f 0.01%,
-  #014b66 100%
+  #017c7f,
+  #00707b,
+  #006376,
+  #00576f,
+  #014b66
 );
 $card-gradient-03: linear-gradient(
   180deg,
-  #016f99 0%,
-  #012866 100%,
-  #014980 100%
+  #016f99,
+  #005d8f,
+  #004c83,
+  #003a75,
+  #012866
 );
 
 $caladapt-colors: (


### PR DESCRIPTION
Updates the background color on the homepage cards to use a linear gradient with non-gray hue variations.

Before:
<img width="1143" alt="Screen Shot 2021-10-29 at 5 00 29 PM" src="https://user-images.githubusercontent.com/161748/139512684-e73b16a9-5b85-4327-bab2-5731aa13eaa1.png">

After:
<img width="1156" alt="Screen Shot 2021-10-29 at 5 00 19 PM" src="https://user-images.githubusercontent.com/161748/139512694-9de0b0fa-ce82-4ab3-be69-e0db7b4bebc9.png">


