### PR TITLE
Line area chart align dates

### DIFF
--- a/src/components/tools/Charts/LineArea/Area.svelte
+++ b/src/components/tools/Charts/LineArea/Area.svelte
@@ -5,6 +5,7 @@
   const { xScale, yScale } = getContext("LayerCake");
 
   export let series;
+  export let setDatetoYearStart = true;
 
   let show = true;
   const legendItems = getContext("Legend");
@@ -16,7 +17,13 @@
   });
 
   $: path = area()
-    .x((d) => $xScale(d.date))
+    .x((d) => {
+      if (setDatetoYearStart) {
+        return $xScale(new Date(Date.UTC(d.date.getUTCFullYear(), 0, 1)));
+      } else {
+        return $xScale(d.date);
+      }
+    })
     .y0((d) => $yScale(d.min))
     .y1((d) => $yScale(d.max));
 

--- a/src/components/tools/Charts/LineArea/Chart.svelte
+++ b/src/components/tools/Charts/LineArea/Chart.svelte
@@ -6,6 +6,7 @@
   import { min, max } from "d3-array";
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
+  import { timeYear } from "d3-time";
 
   import Line from "./Line.svelte";
   import Area from "./Area.svelte";
@@ -34,6 +35,7 @@
     tickFormat: timeFormat("%Y"),
     units: "",
   };
+  export let setDatetoYearStart = true;
 
   let chartContainer;
   const legendItems = writable(null);
@@ -144,6 +146,7 @@
       xScale="{scaleTime()}"
       xDomain="{[xmin, xmax]}"
       yDomain="{[ymin, ymax]}"
+      xPadding="{[10, 10]}"
       data="{data}"
     >
       <Svg>
@@ -161,14 +164,14 @@
         <g class="area-group">
           {#if areaData}
             {#each areaData as area}
-              <Area series="{area}" />
+              <Area series="{area}" setDatetoYearStart="{setDatetoYearStart}" />
             {/each}
           {/if}
         </g>
         <g class="line-group">
           {#if lineData}
             {#each lineData as line}
-              <Line series="{line}" />
+              <Line series="{line}" setDatetoYearStart="{setDatetoYearStart}" />
             {/each}
           {/if}
         </g>

--- a/src/components/tools/Charts/LineArea/Chart.svelte
+++ b/src/components/tools/Charts/LineArea/Chart.svelte
@@ -65,8 +65,9 @@
     // Set X Domain
     xmin = min(data, (arr) => min(arr.values, (d) => d.date));
     xmax = max(data, (arr) => max(arr.values, (d) => d.date));
-    if (xAxis.baseValue === 0) {
-      xmin = xAxis.baseValue;
+    if (setDatetoYearStart) {
+      xmin = timeYear.floor(xmin);
+      xmax = timeYear.floor(xmax);
     }
 
     // Set Y Domain

--- a/src/components/tools/Charts/LineArea/Line.svelte
+++ b/src/components/tools/Charts/LineArea/Line.svelte
@@ -1,9 +1,11 @@
 <script>
   import { getContext } from "svelte";
+  import { line } from "d3-shape";
 
-  const { xGet, yGet } = getContext("LayerCake");
+  const { yGet, xScale } = getContext("LayerCake");
 
   export let series;
+  export let setDatetoYearStart;
 
   let show = true;
   const legendItems = getContext("Legend");
@@ -14,16 +16,15 @@
     }
   });
 
-  $: path = (values) => {
-    return (
-      "M" +
-      values
-        .map((d) => {
-          return $xGet(d) + "," + $yGet(d);
-        })
-        .join("L")
-    );
-  };
+  $: path = line()
+    .x((d) => {
+      if (setDatetoYearStart) {
+        return $xScale(new Date(Date.UTC(d.date.getUTCFullYear(), 0, 1)));
+      } else {
+        return $xScale(d.date);
+      }
+    })
+    .y((d) => $yGet(d));
 </script>
 
 {#if show}


### PR DESCRIPTION
The xaxis in the Line Area chart is a time scale. D3 adds xaxis ticks for the 1st of every year. The data in Annual Avg, Snowpack, Wildfire, & other tools that use the Line Area chart have data with dates at end of the year. I noticed that the values plotted in the chart & ticks don't align. This PR addresses this issue.