### PR TITLE
Align dates chart ticks

### DIFF
--- a/src/components/tools/Charts/LineArea/Chart.svelte
+++ b/src/components/tools/Charts/LineArea/Chart.svelte
@@ -144,6 +144,7 @@
       xScale="{scaleTime()}"
       xDomain="{[xmin, xmax]}"
       yDomain="{[ymin, ymax]}"
+      xPadding="{[10, 10]}"
       data="{data}"
     >
       <Svg>

--- a/src/components/tools/Charts/Scatter/Chart.svelte
+++ b/src/components/tools/Charts/Scatter/Chart.svelte
@@ -101,6 +101,7 @@
       xScale="{scaleTime()}"
       xDomain="{[xmin, xmax]}"
       yDomain="{[ymin, ymax]}"
+      xPadding="{[10, 10]}"
       data="{data}"
     >
       <Svg>

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -21,7 +21,7 @@ export function buildEnvelope(_data) {
   return dataArr.map(([key, value]) => {
     const sortedArr = sort(value);
     return {
-      date: new Date(Date.UTC(key, 11, 31)),
+      date: new Date(Date.UTC(key, 0, 1)),
       min: sortedArr[0],
       max: sortedArr[1],
     };

--- a/src/routes/tools/annual-averages/_data.js
+++ b/src/routes/tools/annual-averages/_data.js
@@ -121,7 +121,7 @@ const fetchSeries = async ({ series, params, method = "GET" }) => {
     if (series.id === "livneh") {
       return {
         ...series,
-        values: values.filter((d) => d.date.getFullYear() <= 2006),
+        values: values.filter((d) => d.date.getUTCFullYear() <= 2006),
       };
     }
     return { ...series, values };

--- a/src/routes/tools/annual-averages/_data.js
+++ b/src/routes/tools/annual-averages/_data.js
@@ -108,7 +108,11 @@ const fetchSeries = async ({ series, params, method = "GET" }) => {
     const { slugs } = series;
     const promises = slugs.map((slug) => fetchEvents({ slug, params, method }));
     const responses = await Promise.all(promises);
-    const values = merge(responses);
+    const mergedResponses = merge(responses);
+    const values = mergedResponses.map(({ date, mean }) => ({
+      date,
+      value: mean,
+    }));
     if (!values.length) {
       throw new Error(`${series.id}: No Data`);
     }
@@ -185,8 +189,13 @@ export async function getEnsemble(config, params, method = "GET") {
  * @return {object} params
  * @return {string} method
  */
-export function getQueryParams({ location, boundary, imperial = true }) {
-  const params = { imperial };
+export function getQueryParams({
+  location,
+  boundary,
+  imperial = true,
+  freq = "AS",
+}) {
+  const params = { imperial, freq };
   let method;
   switch (boundary.id) {
     case "locagrid":

--- a/src/routes/tools/degree-days/_constants.js
+++ b/src/routes/tools/degree-days/_constants.js
@@ -5,7 +5,7 @@ export const CLIMATE_VARIABLE = "tasmax";
 
 export const DEFAULT_CLIMATE_INDICATOR = CLIMATE_INDICATORS[0];
 export const DEFAULT_THRESHOLD_DEGREES = 65;
-export const DEFAULT_FREQUENCY_CODE = "A";
+export const DEFAULT_FREQUENCY_CODE = "AS";
 export const DEFAULT_SELECTED_MONTHS = [5, 6, 7];
 
 export const MAX_THRESHOLD_DEGREES_F = 100;

--- a/src/routes/tools/degree-days/_store.js
+++ b/src/routes/tools/degree-days/_store.js
@@ -58,7 +58,7 @@ export const thresholdStore = writable(DEFAULT_THRESHOLD_DEGREES);
 export const frequencyStore = writable(DEFAULT_FREQUENCY_CODE);
 
 export const frequencyList = [
-  { id: "A", label: "Annually" },
+  { id: "AS", label: "Annually" },
   { id: "M", label: "Monthly" },
 ];
 

--- a/src/routes/tools/snowpack/_data.js
+++ b/src/routes/tools/snowpack/_data.js
@@ -117,12 +117,16 @@ const fetchSeries = async ({
       fetchEvents({ slug, params, method, indicatorId, monthIds, isEnsemble })
     );
     const responses = await Promise.all(promises);
-    const values = merge(responses);
+    const mergedResponses = merge(responses);
+    const values = mergedResponses.map(({ date, value }) => ({
+      date: new Date(Date.UTC(date.getUTCFullYear(), 0, 1)),
+      value,
+    }));
     if (series.id === "livneh") {
       return {
         ...series,
         values: values.filter(
-          (d) => d.date.getFullYear() < OBSERVED_FILTER_YEAR
+          (d) => d.date.getUTCFullYear() < OBSERVED_FILTER_YEAR
         ),
       };
     }

--- a/src/routes/tools/wildfire/_data.js
+++ b/src/routes/tools/wildfire/_data.js
@@ -5,7 +5,7 @@ import { leftPad } from "~/helpers/utilities";
 // Helpers
 import config from "~/helpers/api-config";
 import { handleXHR, fetchData, transformResponse } from "~/helpers/utilities";
-import { OBSERVED_FILTER_YEAR, PRIORITY_4_MODELS } from "../_common/constants";
+import { PRIORITY_4_MODELS } from "../_common/constants";
 
 const { apiEndpoint } = config.env.production;
 
@@ -104,15 +104,11 @@ const fetchSeries = async ({
       fetchEvents({ slug, params, method, indicatorId, monthIds, isEnsemble })
     );
     const responses = await Promise.all(promises);
-    const values = merge(responses);
-    if (series.id === "livneh") {
-      return {
-        ...series,
-        values: values.filter(
-          (d) => d.date.getFullYear() < OBSERVED_FILTER_YEAR
-        ),
-      };
-    }
+    const mergedResponses = merge(responses);
+    const values = mergedResponses.map(({ date, value }) => ({
+      date: new Date(Date.UTC(date.getUTCFullYear(), 0, 1)),
+      value,
+    }));
     return { ...series, values };
   } catch (error) {
     throw new Error(`${series.id}: ${error.message}`);


### PR DESCRIPTION
This aligns the x axis ticks in Line Area chart with the values for Annual Averages, Snowpack, Wildfire & Degree Days tools. It uses the `freq=AS` param in Annual Averages & Degree Days tools to get data from API with dates at start of year. For Snowpack (monthly data only) & Wildfire (annual & monthly) using the `freq` param does not work, since the data is monthly. For these the dates are reset in `fetchSeries` function.