### PR TITLE
Feature: add exception tracking via GA

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,4 +24,7 @@ module.exports = {
   settings: {
     "svelte3/ignore-styles": () => true,
   },
+  globals: {
+    ga: "readonly",
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,6 @@ module.exports = {
     "svelte3/ignore-styles": () => true,
   },
   globals: {
-    ga: "readonly",
+    gtag: "readonly",
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "babel-eslint": "^10.1.0",
         "carbon-components": "^10.30.0",
         "carbon-components-svelte": "^0.42.2",
+        "cross-env": "^7.0.3",
         "eslint": "^7.21.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-svelte3": "^3.1.2",
@@ -2923,6 +2924,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -13787,6 +13806,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development sapper dev --no-hot",
     "build": "cross-env NODE_ENV=production sapper build",
-    "export": "cross-env NODE_ENV=production sapper export --timeout=10000",
+    "export": "sapper export --timeout=10000",
     "start": "node __sapper__/build",
     "deploy": "zx ./scripts/deploy.mjs",
     "deploy-prod": "npm run deploy -- --location=prod",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "dev": "sapper dev --no-hot",
-    "build": "sapper build",
-    "export": "sapper export --timeout=10000",
+    "dev": "cross-env NODE_ENV=development sapper dev --no-hot",
+    "build": "cross-env NODE_ENV=production sapper build",
+    "export": "cross-env NODE_ENV=production sapper export --timeout=10000",
     "start": "node __sapper__/build",
     "deploy": "zx ./scripts/deploy.mjs",
     "deploy-prod": "npm run deploy -- --location=prod",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-eslint": "^10.1.0",
     "carbon-components": "^10.30.0",
     "carbon-components-svelte": "^0.42.2",
+    "cross-env": "^7.0.3",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-svelte3": "^3.1.2",

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -135,7 +135,7 @@ function setEnvBeta() {
 }
 
 function setEnvDev() {
-  process.env.NODE_ENV = "development";
+  process.env.NODE_ENV = "production";
   process.env.DEPLOY = "dev";
 }
 

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -135,7 +135,7 @@ function setEnvBeta() {
 }
 
 function setEnvDev() {
-  process.env.NODE_ENV = "production";
+  process.env.NODE_ENV = "development";
   process.env.DEPLOY = "dev";
 }
 

--- a/src/components/tools/Map/Map.svelte
+++ b/src/components/tools/Map/Map.svelte
@@ -4,6 +4,7 @@
 
   // Helpers
   import { mapboxgl, contextKey } from "./../../../helpers/mapbox";
+  import { logException } from "~/helpers/logging";
 
   setContext(contextKey, {
     getMap: () => map,
@@ -88,10 +89,18 @@
   }
 
   onMount(() => {
-    if (!mapboxgl.supported()) {
-      throw new Error("Your browser does not support Mapbox GL");
+    if (!mapboxgl.supported() && window.alert) {
+      alert(`Your browser does not support our Web Maps. 
+        Please try using another browser.`);
     } else {
       const el = new mapboxgl.Map({ ...options, container, style });
+
+      el.on("error", (error) => {
+        logException(
+          `mapboxgl error: ${error.error.message} sourceId: ${error.sourceId}`
+        );
+        console.warn("mapboxgl error: ", error);
+      });
 
       el.on("load", () => {
         map = el;
@@ -138,7 +147,7 @@
     }
 
     return () => {
-      map.remove();
+      map && map.remove();
     };
   });
 </script>

--- a/src/components/tools/Partials/DownloadChart.svelte
+++ b/src/components/tools/Partials/DownloadChart.svelte
@@ -12,6 +12,7 @@
   import { csvFormat, csvFormatRows } from "d3-dsv";
   import { exportPNG, exportCSV } from "../../../helpers/export";
   import { notifier } from "../../../components/notifications";
+  import { logException } from "~/helpers/logging";
 
   export let open = false;
   export let formats = ["png", "csv"];
@@ -73,6 +74,7 @@
         2000
       );
     } catch (error) {
+      logException(error);
       notifier.error(
         "Download",
         `Error creating ${selected} file`,

--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -1,8 +1,12 @@
 export const logException = (error, fatal = false) => {
   if (process.env.NODE_ENV === "production") {
-    gtag("event", "exception", {
-      description: typeof error === "object" ? error.message : error,
-      fatal,
-    });
+    try {
+      gtag("event", "exception", {
+        description: typeof error === "object" ? error.message : `${error}`,
+        fatal,
+      });
+    } catch (e) {
+      console.warn("gtag exception event capture failed: ", e.message);
+    }
   }
 };

--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -1,8 +1,8 @@
-export const logException = (error, exFatal = false) => {
+export const logException = (error, fatal = false) => {
   if (process.env.NODE_ENV === "production") {
-    ga("send", "exception", {
-      exDescription: typeof error === "object" ? error.message : error,
-      exFatal,
+    gtag("event", "exception", {
+      description: typeof error === "object" ? error.message : error,
+      fatal,
     });
   }
 };

--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -1,0 +1,8 @@
+export const logException = (error, exFatal = false) => {
+  if (process.env.NODE_ENV === "production") {
+    ga("send", "exception", {
+      exDescription: typeof error === "object" ? error.message : error,
+      exFatal,
+    });
+  }
+};

--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -1,5 +1,5 @@
 export const logException = (error, fatal = false) => {
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.DEPLOY === "prod") {
     try {
       gtag("event", "exception", {
         description: typeof error === "object" ? error.message : `${error}`,

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -7,7 +7,7 @@
 
   onMount(() => {
     // only add Google Analytics in production settings
-    if (process.env.NODE_ENV === "production" && !scriptAdded) {
+    if (process.env.DEPLOY === "prod" && !scriptAdded) {
       const script = document.createElement("script");
       script.innerHTML = `
         window.dataLayer = window.dataLayer || [];

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -1,6 +1,26 @@
 <script>
+  import { onMount } from "svelte";
   import { Nav, Footer, BackToTop, SiteAlert } from "~/partials";
   export let segment;
+
+  let scriptAdded = false;
+
+  onMount(() => {
+    // only add Google Analytics in production settings
+    if (process.env.NODE_ENV === "production" && !scriptAdded) {
+      const script = document.createElement("script");
+      script.innerHTML = `
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
+        gtag("config", "G-LPTXXNV75J");
+      `;
+      document.body.append(script);
+      scriptAdded = true;
+    }
+  });
 </script>
 
 <svelte:head>

--- a/src/routes/tools/annual-averages/index.svelte
+++ b/src/routes/tools/annual-averages/index.svelte
@@ -70,6 +70,7 @@
 
   // Helpers
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   // Components
   import ExploreData from "./_ExploreData.svelte";
@@ -145,6 +146,7 @@
       dataStore.set([...envelope, ...observed, ...modelsData]);
     } catch (err) {
       console.log("updateData", err);
+      logException(err);
       notifier.error("Error", err, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -174,6 +176,7 @@
       })
       .catch((error) => {
         console.log("init error", error);
+        logException(error);
         dataStore.set([]);
         notifier.error(
           "Unable to Load Tool",

--- a/src/routes/tools/degree-days/index.svelte
+++ b/src/routes/tools/degree-days/index.svelte
@@ -91,6 +91,7 @@
 
   // Helpers
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   // Components
   import ExploreData from "./_ExploreData.svelte";
@@ -192,6 +193,7 @@
       dataStore.set([...observed, ...modelsData]);
     } catch (error) {
       console.error("updateData", error);
+      logException(error);
       notifier.error("Error", error, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -234,6 +236,7 @@
       })
       .catch((error) => {
         console.error("init error", error);
+        logException(error);
         notifier.error(
           "Unable to Load Tool",
           "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/routes/tools/extended-drought/index.svelte
+++ b/src/routes/tools/extended-drought/index.svelte
@@ -73,6 +73,7 @@
   import { inview } from "svelte-inview/dist/";
 
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   import {
     About,
@@ -158,6 +159,7 @@
       dataStore.set([...envelope, ...observed, ...models]);
     } catch (error) {
       console.error("updateData", error);
+      logException(error);
       notifier.error("Error", error, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -193,6 +195,7 @@
       await update();
     } catch (error) {
       console.error("init error", error);
+      logException(error);
       notifier.error(
         "Unable to Load Tool",
         "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/routes/tools/extreme-heat/index.svelte
+++ b/src/routes/tools/extreme-heat/index.svelte
@@ -72,6 +72,7 @@
 
   // Helpers
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   // Components
   import ExploreData from "./_ExploreData.svelte";
@@ -193,8 +194,8 @@
       );
       dataStore.updateData([...observed, ...modelsData]);
     } catch (err) {
-      // TODO: notify user of error
       console.log("update error", err);
+      logException(err);
       notifier.error("Error", err, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -239,6 +240,7 @@
       })
       .catch((error) => {
         console.log("init error", error);
+        logException(error);
         notifier.error(
           "Unable to Load Tool",
           "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/routes/tools/extreme-weather/index.svelte
+++ b/src/routes/tools/extreme-weather/index.svelte
@@ -57,6 +57,7 @@
 
   // Helpers
   import { getStationById } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   // Components
   import { Header, About, ToolNavigation } from "~/components/tools/Partials";
@@ -148,6 +149,7 @@
     } catch (err) {
       // TODO: notify user of error
       console.log("updateData", err);
+      logException(err);
       notifier.error("Error", err, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -179,6 +181,7 @@
       })
       .catch((error) => {
         console.log("init error", error);
+        logException(error);
         notifier.error(
           "Unable to Load Tool",
           "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/routes/tools/snowpack/index.svelte
+++ b/src/routes/tools/snowpack/index.svelte
@@ -97,6 +97,7 @@
   import { inview } from "svelte-inview/dist/";
 
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
+  import { logException } from "~/helpers/logging";
 
   import {
     About,
@@ -187,6 +188,7 @@
       dataStore.set([...envelope, ...observed, ...models]);
     } catch (error) {
       console.error("updateData", error);
+      logException(error);
       notifier.error("Error", error, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -230,6 +232,7 @@
       await update();
     } catch (error) {
       console.error("init error", error);
+      logException(error);
       notifier.error(
         "Unable to Load Tool",
         "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/routes/tools/wildfire/index.svelte
+++ b/src/routes/tools/wildfire/index.svelte
@@ -81,6 +81,7 @@
 
   import { getFeature, reverseGeocode } from "~/helpers/geocode";
   import { logStores } from "~/helpers/utilities";
+  import { logException } from "~/helpers/logging";
 
   import {
     About,
@@ -185,6 +186,7 @@
       pctndStore.set(getAvgPctNoData($dataStore));
     } catch (error) {
       console.error("updateData", error);
+      logException(error);
       notifier.error("Error", error, 2000);
     } finally {
       isFetchingStore.set(false);
@@ -237,6 +239,7 @@
       await update();
     } catch (error) {
       console.error("init error", error);
+      logException(error);
       notifier.error(
         "Unable to Load Tool",
         "Sorry! Something's probably wrong at our end. Try refereshing your browser. If you still see an error please contact us at support@cal-adapt.org.",

--- a/src/template.html
+++ b/src/template.html
@@ -52,15 +52,6 @@
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-LPTXXNV75J"
     ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-LPTXXNV75J");
-    </script>
   </head>
   <body>
     <!-- The application will be rendered inside this element,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,7 @@ module.exports = {
         "process.browser": true,
         "process.env": {
           NODE_ENV: JSON.stringify(mode),
+          DEPLOY: JSON.stringify(deploy),
           ...featureFlags[deploy],
         },
       }),


### PR DESCRIPTION
Use Google Analytics to log errors in places where things may fail, such as in async operations like network requests and tool UI updates. This will only be enabled for production deploys so that we aren't logging events during development or on the dev server URL.