### PR TITLE
Bugfix: sizing of StaticMap in tool settings panels

### DIFF
--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -109,7 +109,6 @@
 
   const handleLocation = debounce(
     function (feature) {
-      console.log("handleLocation", feature);
       if (feature.geometry.type === "Point") {
         getPointImgSrc(location);
       } else {

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -7,6 +7,7 @@
   // Helpers
   import { mapboxgl } from "~/helpers/mapbox";
   import { serialize, debounce } from "~/helpers/utilities";
+  import { logException } from "~/helpers/logging";
 
   // Props
   export let height = 150;
@@ -26,6 +27,11 @@
   image.onerror = () => {
     loading = false;
     error = true;
+    logException(
+      `StaticMap image failed for ${location && location.title} at ${
+        location && location.center && location.center.join(",")
+      }`
+    );
   };
 
   let loading = true;

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -124,7 +124,7 @@
   button {
     all: unset;
     cursor: pointer;
-    border: 1px solid var(--gray-80);
+    border: 1px solid var(--gray-40);
     min-height: 250px;
     height: auto;
     width: 100%;

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -9,7 +9,6 @@
   import { serialize } from "~/helpers/utilities";
 
   // Props
-  export let width = 150;
   export let height = 150;
   export let location = null;
   export let style = "mapbox/streets-v11";
@@ -17,6 +16,7 @@
   export let zoom = 8;
 
   const { accessToken } = mapboxgl;
+  const MAX_IMG_HEIGHT = 250;
 
   const image = new Image();
   image.onload = () => {
@@ -31,10 +31,19 @@
   let loading = true;
   let loaded = false;
   let error = false;
+  let width;
 
-  $: src = location && location.geometry ? handleLocation(location) : "";
+  height = Math.min(height, MAX_IMG_HEIGHT);
+
+  $: valid = isValidNumber(width) && isValidNumber(height);
+  $: src =
+    valid && location && location.geometry ? handleLocation(location) : "";
   $: alt = location ? `map of ${location.title}` : "";
   $: if (src) image.src = src;
+
+  function isValidNumber(value) {
+    return typeof value === "number" && !isNaN(value);
+  }
 
   function createSrcUrl({ overlay, bounds, params }) {
     return `https://api.mapbox.com/styles/v1/${style}/static/geojson(${overlay})/${bounds}/${width}x${height}?${serialize(
@@ -125,22 +134,24 @@
   }
 </style>
 
-<button on:click>
-  {#if loading}
-    <div class="loading-msg">
-      <InlineLoading description="Loading location map..." />
-    </div>
-  {:else if loaded}
-    <img
-      {...$$restProps}
-      style="{$$restProps.style}"
-      width="{width}"
-      height="{height}"
-      src="{src}"
-      alt="{alt}"
-      transition:fade
-    />
-  {:else if error}
-    <div class="error-text">An error occurred. Unable to load map.</div>
-  {/if}
-</button>
+<div bind:clientWidth="{width}">
+  <button on:click>
+    {#if loading}
+      <div class="loading-msg">
+        <InlineLoading description="Loading location map..." />
+      </div>
+    {:else if loaded}
+      <img
+        {...$$restProps}
+        style="{$$restProps.style}"
+        width="{width}"
+        height="{height}"
+        src="{src}"
+        alt="{alt}"
+        transition:fade
+      />
+    {:else if error}
+      <div class="error-text">An error occurred. Unable to load map.</div>
+    {/if}
+  </button>
+</div>

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -108,6 +108,7 @@
   .static-map {
     all: unset;
     cursor: pointer;
+    border: 1px solid var(--gray-80);
   }
 
   .static-map:hover {
@@ -115,7 +116,7 @@
   }
 
   .static-map:focus {
-    outline: 1px solid var(--gray-80);
+    outline: 1px solid var(--gray-100);
   }
 
   .error-text {
@@ -129,7 +130,9 @@
   {:else if loaded}
     <img
       {...$$restProps}
-      style="width: 100%;{$$restProps.style}"
+      style="{$$restProps.style}"
+      width="{width}"
+      height="{height}"
       src="{src}"
       alt="{alt}"
       transition:fade

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -28,11 +28,8 @@
     error = true;
   };
 
-  // Set to `true` when `loaded` is `true` and `error` is false
-  let loading = false;
-  // Set to `true` when the image is loaded
+  let loading = true;
   let loaded = false;
-  // Set to `true` if an error occurs when loading the image
   let error = false;
 
   $: src = location && location.geometry ? handleLocation(location) : "";
@@ -105,28 +102,34 @@
 </script>
 
 <style>
-  .static-map {
+  button {
     all: unset;
     cursor: pointer;
     border: 1px solid var(--gray-80);
+    min-height: 250px;
+    height: auto;
+    width: 100%;
   }
 
-  .static-map:hover {
+  button:hover {
     box-shadow: var(--box-shadow);
   }
 
-  .static-map:focus {
-    outline: 1px solid var(--gray-100);
+  button:focus {
+    outline: 2px solid var(--gray-100);
   }
 
+  .loading-msg,
   .error-text {
     padding: var(--spacing-32);
   }
 </style>
 
-<button class="static-map" on:click>
+<button on:click>
   {#if loading}
-    <InlineLoading description="Loading location map..." />
+    <div class="loading-msg">
+      <InlineLoading description="Loading location map..." />
+    </div>
   {:else if loaded}
     <img
       {...$$restProps}
@@ -139,7 +142,5 @@
     />
   {:else if error}
     <div class="error-text">An error occurred. Unable to load map.</div>
-  {:else}
-    <p>Something went wrong.</p>
   {/if}
 </button>

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -51,8 +51,6 @@
 
   $: if (src) image.src = src;
 
-  $: console.log(src);
-
   function isValidNumber(value) {
     return typeof value === "number" && !isNaN(value);
   }

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -271,8 +271,7 @@
       <span class="bx--label">Select Location</span>
       <StaticMap
         location="{$location}"
-        width="{350}"
-        height="{350}"
+        height="{250}"
         on:click="{loadLocation}"
       />
       <LearnMoreButton

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -350,8 +350,7 @@
       <span class="bx--label">Select Location</span>
       <StaticMap
         location="{$location}"
-        width="{350}"
-        height="{350}"
+        height="{250}"
         on:click="{loadLocation}"
       />
       <LearnMoreButton

--- a/src/routes/tools/extended-drought/_SettingsPanel.svelte
+++ b/src/routes/tools/extended-drought/_SettingsPanel.svelte
@@ -50,8 +50,7 @@
   <span class="bx--label">Select Location</span>
   <StaticMap
     location="{$location}"
-    width="{350}"
-    height="{350}"
+    height="{250}"
     on:click="{() => showChangeLocation()}"
   />
   <div class="center-row">

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -329,8 +329,7 @@
       <span class="bx--label">Select Location</span>
       <StaticMap
         location="{$location}"
-        width="{350}"
-        height="{350}"
+        height="{250}"
         on:click="{loadLocation}"
       />
       <LearnMoreButton

--- a/src/routes/tools/extreme-weather/_SettingsPanel.svelte
+++ b/src/routes/tools/extreme-weather/_SettingsPanel.svelte
@@ -86,8 +86,7 @@
   <span class="bx--label">Select Station</span>
   <StaticMap
     location="{$location}"
-    width="{350}"
-    height="{350}"
+    height="{250}"
     on:click="{() => showChangeLocation()}"
   />
   <LearnMoreButton

--- a/src/routes/tools/snowpack/_SettingsPanel.svelte
+++ b/src/routes/tools/snowpack/_SettingsPanel.svelte
@@ -114,8 +114,7 @@
     <span class="bx--label">Select Location</span>
     <StaticMap
       location="{$location}"
-      width="{350}"
-      height="{350}"
+      height="{250}"
       on:click="{() => showChangeLocation()}"
     />
     <div class="center-row">

--- a/src/routes/tools/wildfire/_SettingsPanel.svelte
+++ b/src/routes/tools/wildfire/_SettingsPanel.svelte
@@ -38,6 +38,8 @@
   const dispatch = createEventDispatcher();
   const { location } = locationStore;
 
+  let staticMapWidth;
+
   function showLearnMore({ slugs = [], content = "", header = "Glossary" }) {
     dispatch("showLearnMore", { slugs, content, header });
   }
@@ -74,21 +76,25 @@
 {#if activeTab}
   <!-- Chart only settings -->
   <div class="block">
-    <span class="bx--label">Select Location</span>
-    <StaticMap
-      location="{$location}"
-      width="{350}"
-      height="{350}"
-      on:click="{() => showChangeLocation()}"
-    />
-    <div class="center-row">
-      <LearnMoreButton
-        on:click="{() =>
-          showLearnMore({
-            content: SELECT_LOCATION_DESCRIPTION,
-            header: 'Select Location',
-          })}"
-      />
+    <div bind:clientWidth="{staticMapWidth}">
+      <span class="bx--label">Select Location</span>
+      {#if typeof staticMapWidth === "number" && !isNaN(staticMapWidth)}
+        <StaticMap
+          location="{$location}"
+          width="{Math.floor(staticMapWidth)}"
+          height="{250}"
+          on:click="{() => showChangeLocation()}"
+        />
+      {/if}
+      <div class="center-row">
+        <LearnMoreButton
+          on:click="{() =>
+            showLearnMore({
+              content: SELECT_LOCATION_DESCRIPTION,
+              header: 'Select Location',
+            })}"
+        />
+      </div>
     </div>
   </div>
 {/if}

--- a/src/routes/tools/wildfire/_SettingsPanel.svelte
+++ b/src/routes/tools/wildfire/_SettingsPanel.svelte
@@ -38,8 +38,6 @@
   const dispatch = createEventDispatcher();
   const { location } = locationStore;
 
-  let staticMapWidth;
-
   function showLearnMore({ slugs = [], content = "", header = "Glossary" }) {
     dispatch("showLearnMore", { slugs, content, header });
   }
@@ -76,25 +74,20 @@
 {#if activeTab}
   <!-- Chart only settings -->
   <div class="block">
-    <div bind:clientWidth="{staticMapWidth}">
-      <span class="bx--label">Select Location</span>
-      {#if typeof staticMapWidth === "number" && !isNaN(staticMapWidth)}
-        <StaticMap
-          location="{$location}"
-          width="{Math.floor(staticMapWidth)}"
-          height="{250}"
-          on:click="{() => showChangeLocation()}"
-        />
-      {/if}
-      <div class="center-row">
-        <LearnMoreButton
-          on:click="{() =>
-            showLearnMore({
-              content: SELECT_LOCATION_DESCRIPTION,
-              header: 'Select Location',
-            })}"
-        />
-      </div>
+    <span class="bx--label">Select Location</span>
+    <StaticMap
+      location="{$location}"
+      height="{250}"
+      on:click="{() => showChangeLocation()}"
+    />
+    <div class="center-row">
+      <LearnMoreButton
+        on:click="{() =>
+          showLearnMore({
+            content: SELECT_LOCATION_DESCRIPTION,
+            header: 'Select Location',
+          })}"
+      />
     </div>
   </div>
 {/if}

--- a/src/scss/site/_explore-data.scss
+++ b/src/scss/site/_explore-data.scss
@@ -1,10 +1,6 @@
 #explore-data {
   min-height: 50vh;
 
-  .static-map img {
-    max-height: 250px;
-  }
-
   .block {
     background-color: var(--white);
     box-shadow: var(--box-shadow);


### PR DESCRIPTION
Fixes several issues with the `StaticMap` component:

- [x] size the image correctly using the width and height props
- [x] use the full width of the `.block` parent container to size the image
- [x] correct loading, loaded, and error states
- [x] make the image responsive / resize on browser resize
- [x] update usage of Static Map in all tool settings panels

Before:
<img width="359" alt="Screen Shot 2021-12-07 at 4 53 45 PM" src="https://user-images.githubusercontent.com/161748/145129127-171733a3-5770-4474-8b1a-c647776e1bdb.png">

After:
<img width="356" alt="Screen Shot 2021-12-07 at 4 53 58 PM" src="https://user-images.githubusercontent.com/161748/145129140-5be0c432-b8e0-48a3-ad0f-ddb390aaaa91.png">


