### PR TITLE
Prevent search engines from crawling non-prod sites

### DIFF
--- a/featureFlags.json
+++ b/featureFlags.json
@@ -1,14 +1,22 @@
 {
   "beta": {
-    "showBetaBanner": "true"
+    "showBetaBanner": "true",
+    "loggingEnabled": "false",
+    "noRobots": "true"
   },
   "dev": {
-    "showBetaBanner": "false"
+    "showBetaBanner": "false",
+    "loggingEnabled": "false",
+    "noRobots": "true"
   },
   "netlify": {
-    "showBetaBanner": "false"
+    "showBetaBanner": "false",
+    "loggingEnabled": "false",
+    "noRobots": "true"
   },
   "prod": {
-    "showBetaBanner": "false"
+    "showBetaBanner": "false",
+    "loggingEnabled": "true",
+    "noRobots": "false"
   }
 }

--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -1,5 +1,5 @@
 export const logException = (error, fatal = false) => {
-  if (process.env.DEPLOY === "prod") {
+  if (process.env.loggingEnabled) {
     try {
       gtag("event", "exception", {
         description: typeof error === "object" ? error.message : `${error}`,

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -25,6 +25,9 @@
 
 <svelte:head>
   <style src="../scss/main.scss"></style>
+  {#if process.env.noRobots}
+    <meta name="robots" content="none" />
+  {/if}
 </svelte:head>
 
 <div id="skip-to-content">


### PR DESCRIPTION
Adds a "noRobots" env variable in `featureFlags.json` that sets `<meta name="robots" content="none" />` when not deploying to production. 

Also updates the gtag exception logging to use a "loggingEnabled" feature flag which is more clear than using the `DEPLOY` env variable.