### PR TITLE
SLR CIS: delay fetching of raster metadata

### DIFF
--- a/src/routes/tools/slr-coastal-inundation/_Map/Map.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/Map.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher } from "svelte";
+  import { debounce } from "~/helpers/utilities";
   import { Map, NavigationControl } from "~/components/tools/Map";
   import RasterLayers from "./Rasters";
 
@@ -13,6 +14,8 @@
   const zoom = 9;
 
   const dispatch = createEventDispatcher();
+
+  const moveendDelayMS = 1500;
 
   let mapInstance;
   let mbGlMap;
@@ -63,7 +66,7 @@
     style="{styleUrl}"
     on:ready="{handleMapReady}"
     on:destroy="{handleMapDestroy}"
-    on:moveend="{handleMoveend}"
+    on:moveend="{debounce(handleMoveend, moveendDelayMS)}"
   >
     <NavigationControl />
     <RasterLayers mapStyle="{mapStyle}" dataLayers="{dataLayersAugmented}" />


### PR DESCRIPTION
Instead of fetching raster metadata each time the map's `moveend` event fires, add a debounce to the event handler so that it will fire after sequential map `moveend` events, for example if a user is repeatedly zooming and/or panning. 