### PR TITLE
Prettier config fix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
 __sapper__/
 node_modules/
 content/
-
+static/

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  svelteSortOrder: "scripts-styles-markup",
+  svelteSortOrder: "options-scripts-styles-markup",
   svelteStrictMode: true,
   svelteBracketNewLine: true,
   svelteAllowShorthand: true,


### PR DESCRIPTION
Fixes error for prettier-svelte config `svelteSortOrder` rule and ignores the `static` directory.