### PR TITLE
Qa extreme precipitation fix legendtoggle

### DIFF
--- a/src/components/tools/Charts/DotAndWhisker/DotAndWhisker.svelte
+++ b/src/components/tools/Charts/DotAndWhisker/DotAndWhisker.svelte
@@ -5,8 +5,6 @@
 
   export let data;
 
-  let seriesVisibility;
-
   const legendItems = getContext("Legend");
   const { x, y, xScale, yScale, rScale, width, padding } =
     getContext("LayerCake");

--- a/src/components/tools/Charts/DotAndWhisker/DotAndWhisker.svelte
+++ b/src/components/tools/Charts/DotAndWhisker/DotAndWhisker.svelte
@@ -5,6 +5,9 @@
 
   export let data;
 
+  let seriesVisibility;
+
+  const legendItems = getContext("Legend");
   const { x, y, xScale, yScale, rScale, width, padding } =
     getContext("LayerCake");
   const dispatch = createEventDispatcher();
@@ -21,6 +24,9 @@
 
   $: $rScale.rangeRound([0, $width]);
   $: $xScale.rangeRound([0, $rScale.bandwidth()]);
+  $: seriesVisibility = Object.fromEntries(
+    $legendItems.map(({ id, visible }) => [id, visible])
+  );
 </script>
 
 <g
@@ -35,6 +41,7 @@
           class="{d.id}"
           use:mouseoverFocus="{(e) => dispatch('mousemove', { e, props: d })}"
           on:mousemove="{handleMousemove(d)}"
+          class:hidden="{!seriesVisibility[d.id]}"
         >
           <line
             class="ci"

--- a/src/routes/tools/extreme-precipitation/index.svelte
+++ b/src/routes/tools/extreme-precipitation/index.svelte
@@ -467,7 +467,7 @@
           <li>
             <a
               target="_blank"
-              href="https://ral.ucar.edu/staff/ericg/Intro2EVT.pdf"
+              href="https://staff.ral.ucar.edu/ericg/Intro2EVT.pdf"
               >Gilleland, E. (2015).</a
             > Introduction to Extreme Value Theorem Analysis. National Center for
             Atmospheric Research.


### PR DESCRIPTION
When users click on the legend buttons in a chart, the visibility of the corresponding series in the chart is toggled on/off. The main purpose of this QA fix is to add this functionality to the Intensity chart.