### PR TITLE
bug fix - chart title does not update in Extreme Weather tool

### DIFF
--- a/src/routes/tools/extreme-weather/_ExploreData.svelte
+++ b/src/routes/tools/extreme-weather/_ExploreData.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { afterUpdate } from "svelte";
   import { Loading } from "carbon-components-svelte";
   import { format } from "d3-format";
 
@@ -65,9 +66,9 @@
     histogramData = null;
   }
 
-  $: if ($location && $location.title) {
+  afterUpdate(() => {
     chartTitle = `${$location.title} (${$location.geometry.coordinates[0]}°, ${$location.geometry.coordinates[1]}°)`;
-  }
+  });
 
   async function loadLearnMore({
     slugs = [],


### PR DESCRIPTION
This PR fixes the issue of weather station name not updating in chart title for the Extreme Weather tool.