### PR TITLE
Bug fix stats support keyboardentry

### DIFF
--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -55,8 +55,8 @@
    * the combobox selected index if the year matches an item in the combobox dropdown menu
    **/
   function updateIndex(e) {
-    const { key, keyCode, target } = e;
-    if (["Enter", "Tab"].includes(key) || [13, 9].includes(keyCode)) {
+    const { key, target } = e;
+    if (["Enter", "Tab"].includes(key)) {
       const { value, id } = target;
       switch (id) {
         case "years-select-start":

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -46,6 +46,9 @@
   // If user confirms changes, dispatch change event with selected groupd and period
   // If user has selected a custom period, create a new period object
   function update() {
+    if (startYear_selectedIndex < 0 || endYear_selectedIndex < 0) {
+      return;
+    }
     group = groupList.find(({ id }) => id === selectedGroupId);
     if (selectedPeriodId === "custom") {
       const start = getItem(startYear_selectedIndex);
@@ -102,12 +105,16 @@
         titleText="Start"
         placeholder="Select start year"
         items="{items}"
+        invalid="{startYear_selectedIndex < 0}"
+        invalidText="Select Start Year"
       />
       <ComboBox
         bind:selectedIndex="{endYear_selectedIndex}"
         titleText="End"
         placeholder="Select end year"
         items="{filteredItems}"
+        invalid="{endYear_selectedIndex < 0}"
+        invalidText="Select End Year"
       />
     </div>
   {/if}

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -26,9 +26,7 @@
   let endYear_selectedIndex = -1;
   let filteredItems;
 
-  const getItem = (i) => (items[i] ? +items[i].text : "N/A");
-  const getFilteredItem = (i) =>
-    filteredItems[i] ? +filteredItems[i].text : "N/A";
+  const getItemByIndex = (i, arr) => (arr[i] ? arr[i].text : null);
 
   function updateLinkedList() {
     if (startYear_selectedIndex < 0) {
@@ -52,13 +50,13 @@
   // If user has selected a custom period, create a new period object
   // If either start or end year is not selected do not dispatch change event
   function update() {
-    if (startYear_selectedIndex < 0 || endYear_selectedIndex < 0) {
-      return;
-    }
     group = groupList.find(({ id }) => id === selectedGroupId);
     if (selectedPeriodId === "custom") {
-      const start = getItem(startYear_selectedIndex);
-      const end = getFilteredItem(endYear_selectedIndex);
+      if (startYear_selectedIndex < 0 || endYear_selectedIndex < 0) {
+        return;
+      }
+      const start = getItemByIndex(startYear_selectedIndex, items);
+      const end = getItemByIndex(endYear_selectedIndex, filteredItems);
       period = {
         id: "custom",
         label: `${start}-${end}`,

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -28,6 +28,10 @@
 
   const getItemByIndex = (i, arr) => (arr[i] ? arr[i].text : null);
 
+  /**
+   * When start year is selected, the items in the end year combobox dropdown menu are filtered
+   * to show only values greater than the start year
+   **/
   function updateLinkedList() {
     if (startYear_selectedIndex < 0) {
       filteredItems = items;
@@ -37,11 +41,19 @@
     }
   }
 
+  /**
+   * When user types in the year, the combobox dropdown menu is filtered to show only
+   * values that complete the characters typed in the combobox
+   **/
   function shouldFilterItem(item, value) {
     if (!value) return true;
     return item.text.includes(value);
   }
 
+  /**
+   * When user presses the Enter or Tab key in combobox after typing in a year, update
+   * the combobox selected index if the year matches an item in the combobox dropdown menu
+   **/
   function updateIndex(e) {
     const { key, keyCode, target } = e;
     if (["Enter", "Tab"].includes(key) || [13, 9].includes(keyCode)) {
@@ -65,9 +77,12 @@
   $: items = yearsList.map((d) => ({ id: d, text: `${d}` }));
   $: startYear_selectedIndex, updateLinkedList();
 
-  // If user confirms changes, dispatch change event with selected groupd and period
-  // If user has selected a custom period, create a new period object
-  // If either start or end year is not selected do not dispatch change event
+  /**
+   * Dispatch change event with current group object and selected period object when user selects Confirm.
+   * For custom period:
+   *  - check if both start and end year are defined
+   *  - create a new period object
+   **/
   function update() {
     group = groupList.find(({ id }) => id === selectedGroupId);
     if (selectedPeriodId === "custom") {

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -30,6 +30,10 @@
 
   const highlightClass = ".bx--list-box__menu-item--highlighted";
 
+  $: yearsList = range(dateRange[0], dateRange[1] + 1, 1);
+  $: items = yearsList.map((d) => ({ id: d, text: `${d}` }));
+  $: startYear_selectedIndex, updateLinkedList();
+
   const getItemValue = (i, arr) => (arr[i] ? arr[i].text : null);
   const getItemIndex = (value, arr) =>
     arr.findIndex(({ text }) => text === value);
@@ -103,10 +107,6 @@
       }
     }
   }
-
-  $: yearsList = range(dateRange[0], dateRange[1] + 1, 1);
-  $: items = yearsList.map((d) => ({ id: d, text: `${d}` }));
-  $: startYear_selectedIndex, updateLinkedList();
 
   /**
    * Dispatch change event with current group object and selected period object when user selects Confirm.

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -35,8 +35,13 @@
     arr.findIndex(({ text }) => text === value);
 
   /**
-   * Search for highlighted items in ComboBox Dropdown and returns the index
-   * Returns -1 if no highlighted item
+   * After entering the partial year in input box, the user might use ArrowDown or ArrowUp keys
+   * to hihglight an item in the ComboBox dropdown menu. This function:
+   *  - finds the highlighted item
+   *  - search list items by highlighted item id
+   *  - returns array index of highlighted item
+   * TODO: This functionality may not be need with new version of ComboBox component
+   * https://github.com/carbon-design-system/carbon-components-svelte/issues/195
    **/
   const getHighlightedIndex = (node, arr) => {
     if (!node) return -1;
@@ -70,8 +75,7 @@
   /**
    * When user presses the Enter or Tab key in combobox after typing in a year, update
    * the combobox selected index if the year matches an item in the combobox dropdown menu
-   * TODO: Keyboard support for ComboBox component has been implemented in latest version
-   * of carbon-components-svelte. So may not need this function.
+   * TODO: This functionality may not be need with new version of ComboBox component
    * https://github.com/carbon-design-system/carbon-components-svelte/issues/195
    **/
   function updateIndex(e) {

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -39,12 +39,18 @@
     }
   }
 
+  function shouldFilterItem(item, value) {
+    if (!value) return true;
+    return item.text.includes(value);
+  }
+
   $: yearsList = range(dateRange[0], dateRange[1] + 1, 1);
   $: items = yearsList.map((d) => ({ id: d, text: `${d}` }));
   $: startYear_selectedIndex, updateLinkedList();
 
   // If user confirms changes, dispatch change event with selected groupd and period
   // If user has selected a custom period, create a new period object
+  // If either start or end year is not selected do not dispatch change event
   function update() {
     if (startYear_selectedIndex < 0 || endYear_selectedIndex < 0) {
       return;
@@ -106,7 +112,8 @@
         placeholder="Select start year"
         items="{items}"
         invalid="{startYear_selectedIndex < 0}"
-        invalidText="Select Start Year"
+        invalidText="Select a year from the list"
+        shouldFilterItem="{shouldFilterItem}"
       />
       <ComboBox
         bind:selectedIndex="{endYear_selectedIndex}"
@@ -114,7 +121,8 @@
         placeholder="Select end year"
         items="{filteredItems}"
         invalid="{endYear_selectedIndex < 0}"
-        invalidText="Select End Year"
+        invalidText="Select a year from the list"
+        shouldFilterItem="{shouldFilterItem}"
       />
     </div>
   {/if}

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -42,6 +42,25 @@
     return item.text.includes(value);
   }
 
+  function updateIndex(e) {
+    const { key, keyCode, target } = e;
+    if (["Enter", "Tab"].includes(key) || [13, 9].includes(keyCode)) {
+      const { value, id } = target;
+      switch (id) {
+        case "years-select-start":
+          startYear_selectedIndex = items.findIndex((d) => d.text === value);
+          return;
+        case "years-select-end":
+          endYear_selectedIndex = filteredItems.findIndex(
+            (d) => d.text === value
+          );
+          return;
+        default:
+          return;
+      }
+    }
+  }
+
   $: yearsList = range(dateRange[0], dateRange[1] + 1, 1);
   $: items = yearsList.map((d) => ({ id: d, text: `${d}` }));
   $: startYear_selectedIndex, updateLinkedList();
@@ -112,6 +131,8 @@
         invalid="{startYear_selectedIndex < 0}"
         invalidText="Select a year from the list"
         shouldFilterItem="{shouldFilterItem}"
+        on:keydown="{updateIndex}"
+        id="years-select-start"
       />
       <ComboBox
         bind:selectedIndex="{endYear_selectedIndex}"
@@ -121,6 +142,8 @@
         invalid="{endYear_selectedIndex < 0}"
         invalidText="Select a year from the list"
         shouldFilterItem="{shouldFilterItem}"
+        on:keydown="{updateIndex}"
+        id="years-select-end"
       />
     </div>
   {/if}

--- a/src/components/tools/Stats/StatOptions.svelte
+++ b/src/components/tools/Stats/StatOptions.svelte
@@ -25,8 +25,25 @@
   let startYear_selectedIndex = -1;
   let endYear_selectedIndex = -1;
   let filteredItems;
+  let startYearListRef;
+  let endYearListRef;
 
-  const getItemByIndex = (i, arr) => (arr[i] ? arr[i].text : null);
+  const highlightClass = ".bx--list-box__menu-item--highlighted";
+
+  const getItemValue = (i, arr) => (arr[i] ? arr[i].text : null);
+  const getItemIndex = (value, arr) =>
+    arr.findIndex(({ text }) => text === value);
+
+  /**
+   * Search for highlighted items in ComboBox Dropdown and returns the index
+   * Returns -1 if no highlighted item
+   **/
+  const getHighlightedIndex = (node, arr) => {
+    if (!node) return -1;
+    const el = node.querySelector(highlightClass);
+    if (!el) return -1;
+    return getItemIndex(el.id, arr);
+  };
 
   /**
    * When start year is selected, the items in the end year combobox dropdown menu are filtered
@@ -53,19 +70,29 @@
   /**
    * When user presses the Enter or Tab key in combobox after typing in a year, update
    * the combobox selected index if the year matches an item in the combobox dropdown menu
+   * TODO: Keyboard support for ComboBox component has been implemented in latest version
+   * of carbon-components-svelte. So may not need this function.
+   * https://github.com/carbon-design-system/carbon-components-svelte/issues/195
    **/
   function updateIndex(e) {
     const { key, target } = e;
+    const { value, id } = target;
+    let idx;
     if (["Enter", "Tab"].includes(key)) {
-      const { value, id } = target;
       switch (id) {
         case "years-select-start":
-          startYear_selectedIndex = items.findIndex((d) => d.text === value);
+          idx = getItemIndex(value, items);
+          if (idx < 0) {
+            idx = getHighlightedIndex(startYearListRef, items);
+          }
+          startYear_selectedIndex = idx;
           return;
         case "years-select-end":
-          endYear_selectedIndex = filteredItems.findIndex(
-            (d) => d.text === value
-          );
+          idx = getItemIndex(value, filteredItems);
+          if (idx < 0) {
+            idx = getHighlightedIndex(endYearListRef, filteredItems);
+          }
+          endYear_selectedIndex = idx;
           return;
         default:
           return;
@@ -89,8 +116,8 @@
       if (startYear_selectedIndex < 0 || endYear_selectedIndex < 0) {
         return;
       }
-      const start = getItemByIndex(startYear_selectedIndex, items);
-      const end = getItemByIndex(endYear_selectedIndex, filteredItems);
+      const start = getItemValue(startYear_selectedIndex, items);
+      const end = getItemValue(endYear_selectedIndex, filteredItems);
       period = {
         id: "custom",
         label: `${start}-${end}`,
@@ -148,6 +175,7 @@
         shouldFilterItem="{shouldFilterItem}"
         on:keydown="{updateIndex}"
         id="years-select-start"
+        bind:listRef="{startYearListRef}"
       />
       <ComboBox
         bind:selectedIndex="{endYear_selectedIndex}"
@@ -159,6 +187,7 @@
         shouldFilterItem="{shouldFilterItem}"
         on:keydown="{updateIndex}"
         id="years-select-end"
+        bind:listRef="{endYearListRef}"
       />
     </div>
   {/if}


### PR DESCRIPTION
Currently typing in a year in the Change Stats dialog (instead of selecting year from the combobox dropdown menu) for a Stats box returns `N/A`. This PR includes the foll:
- simplifies getting index of a value in the item list
- shows an invalid state if the `start` & `end` year are missing for custom period
- adds support for entering a year using the keyboard
- filters list as user types in a year
- adds comments
