### PR TITLE
SLR CIS tool: clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@mapbox/togeojson": "^0.16.0",
         "@turf/area": "^6.3.0",
         "@turf/bbox": "^6.0.1",
-        "@turf/bbox-polygon": "^6.5.0",
         "@turf/center": "^6.0.1",
         "@turf/helpers": "^6.3.0",
         "@turf/simplify": "^5.1.5",
@@ -3269,17 +3268,6 @@
       "dependencies": {
         "@turf/helpers": "^6.4.0",
         "@turf/meta": "^6.4.0"
-      }
-    },
-    "node_modules/@turf/bbox-polygon": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.5.0.tgz",
-      "integrity": "sha512-+/r0NyL1lOG3zKZmmf6L8ommU07HliP4dgYToMoTxqzsWzyLjaj/OzgQ8rBmv703WJX+aS6yCmLuIhYqyufyuw==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/center": {
@@ -20994,14 +20982,6 @@
       "requires": {
         "@turf/helpers": "^6.4.0",
         "@turf/meta": "^6.4.0"
-      }
-    },
-    "@turf/bbox-polygon": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.5.0.tgz",
-      "integrity": "sha512-+/r0NyL1lOG3zKZmmf6L8ommU07HliP4dgYToMoTxqzsWzyLjaj/OzgQ8rBmv703WJX+aS6yCmLuIhYqyufyuw==",
-      "requires": {
-        "@turf/helpers": "^6.5.0"
       }
     },
     "@turf/center": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@mapbox/togeojson": "^0.16.0",
     "@turf/area": "^6.3.0",
     "@turf/bbox": "^6.0.1",
-    "@turf/bbox-polygon": "^6.5.0",
     "@turf/center": "^6.0.1",
     "@turf/helpers": "^6.3.0",
     "@turf/simplify": "^5.1.5",

--- a/src/routes/tools/slr-coastal-inundation/_Map/Map.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/Map.svelte
@@ -112,7 +112,7 @@
     <NavigationControl />
     <Search on:change="{handleSearchChange}" />
 
-    {#if zoom >= 7}
+    {#if zoom >= 8}
       <RasterLayers
         mapStyle="{mapStyle}"
         beforeId="{beforeId}"
@@ -120,7 +120,7 @@
       />
     {/if}
 
-    {#if zoom < 7}
+    {#if zoom < 8}
       <TileIndexes
         mapStyle="{mapStyle}"
         beforeId="{beforeId}"

--- a/src/routes/tools/slr-coastal-inundation/_Map/Rasters.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/Rasters.svelte
@@ -19,8 +19,9 @@
     "raster-opacity": 0.5,
   };
 
-  const mapLayersProps = ({ id, checked, color, tileUrls }) => ({
+  const mapLayersProps = ({ id, checked, color, tileUrls, slugs }) => ({
     id,
+    slugs,
     tileUrls: tileUrls.map((url) => `${url}?style=${color}`),
     visibility: checked ? VISIBLE : NONE,
   });
@@ -48,12 +49,11 @@
   });
 
   function addRasterLayers() {
-    rasterLayersProps.forEach(({ id, tileUrls, visibility }) => {
+    rasterLayersProps.forEach(({ tileUrls, visibility, slugs }) => {
       tileUrls.forEach((url, index) => {
         layerHandler.addMapLayer({
-          id,
+          id: slugs[index],
           asset: url,
-          index,
           visibility,
           paintProps,
         });
@@ -62,13 +62,13 @@
   }
 
   function reapplyRasterLayers() {
-    rasterLayersProps.forEach(({ id, tileUrls, visibility }) => {
+    rasterLayersProps.forEach(({ tileUrls, visibility, slugs }) => {
       tileUrls.forEach((url, index) => {
-        layerHandler.removeMapLayer(id, index);
+        const slug = slugs[index];
+        layerHandler.removeMapLayer(slug);
         layerHandler.addMapLayer({
-          id,
+          id: slug,
           asset: url,
-          index,
           visibility,
           paintProps,
         });
@@ -77,9 +77,9 @@
   }
 
   function removePreviousRasterLayers() {
-    prevRasterLayerProps.forEach(({ id, tileUrls }) => {
+    prevRasterLayerProps.forEach(({ tileUrls, slugs }) => {
       tileUrls.forEach((_url, index) => {
-        layerHandler.removeMapLayer(id, index);
+        layerHandler.removeMapLayer(slugs[index]);
       });
     });
   }
@@ -88,9 +88,9 @@
     if (!map.getStyle()) {
       return;
     }
-    rasterLayersProps.forEach(({ id, tileUrls }) => {
+    rasterLayersProps.forEach(({ tileUrls, slugs }) => {
       tileUrls.forEach((_url, index) => {
-        layerHandler.removeMapLayer(id, index);
+        layerHandler.removeMapLayer(slugs[index]);
       });
     });
   }

--- a/src/routes/tools/slr-coastal-inundation/_Map/Rasters.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/Rasters.svelte
@@ -9,9 +9,6 @@
   export let beforeId;
   export let dataLayers = [];
 
-  let prevRasterLayerProps = [];
-  let prevMapStyle = mapStyle;
-
   const { getMap } = getContext(contextKey);
   const map = getMap();
 
@@ -26,15 +23,17 @@
     visibility: checked ? VISIBLE : NONE,
   });
 
-  if (map && map.getStyle()) {
-    map.on("styledata", handleStyleDataChange);
-  }
-
-  $: layerHandler = new MapLayerHandler({
+  let prevRasterLayerProps = [];
+  let prevMapStyle = mapStyle;
+  let layerHandler = new MapLayerHandler({
     map,
     beforeId,
     layerType: "raster",
   });
+
+  if (map && map.getStyle()) {
+    map.on("styledata", handleStyleDataChange);
+  }
 
   $: rasterLayersProps = dataLayers
     .filter((d) => Array.isArray(d.tileUrls) && d.tileUrls.length)
@@ -98,6 +97,7 @@
   // keeps the map layers in sync when the map style changes
   function handleStyleDataChange() {
     if (mapStyle !== prevMapStyle) {
+      layerHandler.beforeId = beforeId;
       reapplyRasterLayers();
       prevMapStyle = mapStyle;
     }

--- a/src/routes/tools/slr-coastal-inundation/_Map/TileCentroids.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/TileCentroids.svelte
@@ -10,9 +10,6 @@
   export let dataLayers = [];
   export let centroids;
 
-  let prevMapStyle = mapStyle;
-  let prevLayerProps = [];
-
   const { getMap } = getContext(contextKey);
   const map = getMap();
 
@@ -26,15 +23,17 @@
     visibility: checked ? VISIBLE : NONE,
   });
 
-  if (map && map.getStyle()) {
-    map.on("styledata", handleStyleDataChange);
-  }
-
-  $: layerHandler = new MapLayerHandler({
+  let prevMapStyle = mapStyle;
+  let prevLayerProps = [];
+  let layerHandler = new MapLayerHandler({
     map,
     beforeId,
     layerType: "circle",
   });
+
+  if (map && map.getStyle()) {
+    map.on("styledata", handleStyleDataChange);
+  }
 
   $: layerProps =
     Boolean(centroids) &&
@@ -78,6 +77,7 @@
 
   function handleStyleDataChange() {
     if (mapStyle !== prevMapStyle) {
+      layerHandler.beforeId = beforeId;
       reapplyCentroidsLayer();
       prevMapStyle = mapStyle;
     }

--- a/src/routes/tools/slr-coastal-inundation/_Map/TileIndexes.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/TileIndexes.svelte
@@ -10,9 +10,6 @@
   export let dataLayers = [];
   export let geojsons = new Map();
 
-  let prevMapStyle = mapStyle;
-  let prevLayerProps = [];
-
   const { getMap } = getContext(contextKey);
   const map = getMap();
 
@@ -29,15 +26,17 @@
     visibility: checked ? VISIBLE : NONE,
   });
 
-  if (map && map.getStyle()) {
-    map.on("styledata", handleStyleDataChange);
-  }
-
-  $: layerHandler = new MapLayerHandler({
+  let prevMapStyle = mapStyle;
+  let prevLayerProps = [];
+  let layerHandler = new MapLayerHandler({
     map,
     beforeId,
     layerType: "fill",
   });
+
+  if (map && map.getStyle()) {
+    map.on("styledata", handleStyleDataChange);
+  }
 
   $: layerProps = Boolean(geojsons.size) && dataLayers.map(mapLayersProps);
 
@@ -87,6 +86,7 @@
   // keeps the map layers in sync when the map style changes
   function handleStyleDataChange() {
     if (mapStyle !== prevMapStyle) {
+      layerHandler.beforeId = beforeId;
       reapplyGeoJsonLayers();
       prevMapStyle = mapStyle;
     }

--- a/src/routes/tools/slr-coastal-inundation/_Map/TileIndexes.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Map/TileIndexes.svelte
@@ -23,7 +23,7 @@
   });
 
   const mapLayersProps = ({ id, checked, color }) => ({
-    id,
+    id: `${id}-tile-index`,
     color: LAYER_COLORS.get(color),
     data: geojsons.get(id),
     visibility: checked ? VISIBLE : NONE,

--- a/src/routes/tools/slr-coastal-inundation/_SettingsPanel.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_SettingsPanel.svelte
@@ -5,7 +5,6 @@
     floodScenarioStore,
     timeFrameStore,
     dataLayersStore,
-    dataLayersAugmentedStore,
   } from "./_store";
 
   import { TIME_PERIODS, FLOOD_SCENARIOS } from "./_constants";
@@ -38,7 +37,7 @@
 <div class="block">
   <SelectLayers
     title="Select Map Data Layers"
-    items="{[...$dataLayersAugmentedStore]}"
+    items="{[...$dataLayersStore]}"
     on:change="{changeDataLayers}"
   />
   <LearnMoreButton

--- a/src/routes/tools/slr-coastal-inundation/_Title.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_Title.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { Button, InlineNotification } from "carbon-components-svelte";
-  import { Location16 } from "carbon-icons-svelte";
+  import { InlineNotification } from "carbon-components-svelte";
   import { getCSSProp } from "~/helpers/utilities";
 
   export let floodScenario;

--- a/src/routes/tools/slr-coastal-inundation/_constants.js
+++ b/src/routes/tools/slr-coastal-inundation/_constants.js
@@ -12,7 +12,7 @@ export const LAYER_COLORS = new Map([
 
 export const DEFAULT_FLOOD_SCENARIO = "med";
 export const DEFAULT_TIME_FRAME = "[2020,2040]";
-export const DEFAULT_MAP_BBOX = [-121.478, 38.132, -122.991, 37.46]; // SF Bay, roughly
+export const DEFAULT_MAP_BBOX = [-122.9204, 37.5257, -121.5595, 38.1288];
 
 export const DEFAULT_INITIAL_CONFIG = {
   floodScenario: DEFAULT_FLOOD_SCENARIO,

--- a/src/routes/tools/slr-coastal-inundation/_constants.js
+++ b/src/routes/tools/slr-coastal-inundation/_constants.js
@@ -1,5 +1,3 @@
-import { DEFAULT_BOUNDARIES } from "../_common/constants";
-
 export const DL_Cosmos = "cosmos";
 export const DL_Calflod5m = "calflod3dtfs_5m";
 export const DL_Calflod50m = "calflod3dtfs_50m";
@@ -12,23 +10,15 @@ export const LAYER_COLORS = new Map([
   ["rsblue", "#25C7FA"],
 ]);
 
-export const DEFAULT_CENTER = [-122.2813, 37.7813];
 export const DEFAULT_FLOOD_SCENARIO = "med";
 export const DEFAULT_TIME_FRAME = "[2020,2040]";
 export const DEFAULT_MAP_BBOX = [-121.478, 38.132, -122.991, 37.46]; // SF Bay, roughly
 
 export const DEFAULT_INITIAL_CONFIG = {
-  boundaryId: "place",
   floodScenario: DEFAULT_FLOOD_SCENARIO,
   timeFrame: DEFAULT_TIME_FRAME,
-  lng: DEFAULT_CENTER[0],
-  lat: DEFAULT_CENTER[1],
-  imperial: false,
+  bbox: DEFAULT_MAP_BBOX,
 };
-
-export const BOUNDARIES = DEFAULT_BOUNDARIES.filter((d) =>
-  ["counties", "censustracts", "hydrounits", "place"].includes(d.id)
-);
 
 export const TIME_PERIODS = [
   {

--- a/src/routes/tools/slr-coastal-inundation/_data.js
+++ b/src/routes/tools/slr-coastal-inundation/_data.js
@@ -1,4 +1,3 @@
-import bboxPolygon from "@turf/bbox-polygon";
 import config from "~/helpers/api-config";
 
 const {
@@ -7,18 +6,12 @@ const {
   },
 } = config;
 
-export const getRasterMetaData = (scenario, source, timeFrame, geom) =>
+export const getRasterMetaData = (scenario, source, timeFrame, bbox) =>
   fetch(
     `${apiEndpoint}/rstores/?slug=${source}&slug=${scenario}&slug=${timeFrame}&bbintersects=${encodeURIComponent(
-      geom
+      bbox
     )}`
   ).then((res) => res.json());
-
-export const toBBoxPolygon = (coords) => {
-  if (Array.isArray(coords) && coords.length) {
-    return bboxPolygon(coords);
-  }
-};
 
 export const getGeoJson = (ids) => {
   if (Array.isArray(ids) && ids.length) {

--- a/src/routes/tools/slr-coastal-inundation/_data.js
+++ b/src/routes/tools/slr-coastal-inundation/_data.js
@@ -6,6 +6,8 @@ const {
   },
 } = config;
 
+// queries the cal-adapt API for slr sources raster metadata
+// this metadata includes the tile URLs used to render map tiles
 export const getRasterMetaData = (scenario, source, timeFrame, bbox) =>
   fetch(
     `${apiEndpoint}/rstores/?slug=${source}&slug=${scenario}&slug=${timeFrame}&bbintersects=${encodeURIComponent(
@@ -13,6 +15,7 @@ export const getRasterMetaData = (scenario, source, timeFrame, bbox) =>
     )}`
   ).then((res) => res.json());
 
+// fetches geojson files from static/data that are used for displaying tile indexes & centroids
 export const getGeoJson = (ids) => {
   if (Array.isArray(ids) && ids.length) {
     return Promise.all(

--- a/src/routes/tools/slr-coastal-inundation/_store.js
+++ b/src/routes/tools/slr-coastal-inundation/_store.js
@@ -147,7 +147,7 @@ export const rasterMetaDataStore = makeCustomWritableStore(RASTER_METADATA, {
   ],
 });
 
-// augments the data layers store to include the zxy tiles url for each layer
+// augments the data layers store to include the map tile urls and slugs for each layer
 // from the rasterMetaDataStore
 export const dataLayersAugmentedStore = Object.defineProperty(
   derived(

--- a/src/routes/tools/slr-coastal-inundation/_store.js
+++ b/src/routes/tools/slr-coastal-inundation/_store.js
@@ -57,6 +57,9 @@ export const mapBBoxStore = makeCustomWritableStore(DEFAULT_MAP_BBOX, {
 const getTileUrls = (value) =>
   Array.isArray(value) && value.length ? value.map((d) => d.tileurl) : [];
 
+const getSlugs = (value) =>
+  Array.isArray(value) && value.length ? value.map((d) => d.slug) : [];
+
 export const dataLayersStore = makeCustomWritableStore(DATA_LAYERS, {
   name: "dataLayersStore",
   getters: [
@@ -152,6 +155,7 @@ export const dataLayersAugmentedStore = Object.defineProperty(
     ([$dataLayersStore, $rasterMetaDataStore]) =>
       $dataLayersStore.map((data) => {
         const tileUrls = getTileUrls($rasterMetaDataStore[data.id]);
+        const slugs = getSlugs($rasterMetaDataStore[data.id]);
         return {
           ...data,
           ...(!tileUrls.length && {
@@ -162,6 +166,7 @@ export const dataLayersAugmentedStore = Object.defineProperty(
             disabled: false,
           }),
           tileUrls,
+          slugs,
         };
       })
   ),

--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -61,7 +61,6 @@
   import { Loading } from "carbon-components-svelte";
   import { inview } from "svelte-inview/dist/";
 
-  import { getFeature, reverseGeocode } from "~/helpers/geocode";
   import { logStores } from "~/helpers/utilities";
   import { logException } from "~/helpers/logging";
 
@@ -161,9 +160,10 @@
     }
   }
 
-  async function initApp({ floodScenario, timeFrame }) {
+  async function initApp({ floodScenario, timeFrame, bbox }) {
     floodScenarioStore.set(floodScenario);
     timeFrameStore.set(timeFrame);
+    mapBBoxStore.set(bbox);
   }
 
   onMount(async () => {

--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -78,11 +78,10 @@
   import { DL_Cosmos, DL_Calflod5m, DL_Calflod50m } from "./_constants";
   import { getRasterMetaData } from "./_data";
 
-  import { isFetchingStore, datasetStore } from "../_common/stores";
+  import { isFetchingStore } from "../_common/stores";
   import {
     floodScenarioStore,
     timeFrameStore,
-    dataLayersStore,
     mapBBoxStore,
     rasterMetaDataStore,
     dataLayersAugmentedStore,
@@ -114,15 +113,13 @@
   $: resources = [...externalResources, ...relatedTools];
   $: update($bbox, $floodScenarioStore, $tfTileLabel);
 
+  // log changes to stores when in development
   if (process.env.NODE_ENV !== "production") {
     logStores(
       floodScenarioStore,
       timeFrameStore,
-      dataLayersStore,
       isFetchingStore,
-      datasetStore,
       mapBBoxStore,
-      rasterMetaDataStore,
       dataLayersAugmentedStore
     );
   }
@@ -207,10 +204,7 @@
 
 <div class="bx--grid">
   <div id="about" use:inview="{{}}" on:enter="{handleEntry}">
-    <About
-      datasets="{datasets}"
-      on:datasetLoaded="{(e) => datasetStore.set(e.detail)}"
-    >
+    <About datasets="{datasets}">
       <div slot="description">
         {@html aboutContent}
       </div>

--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -76,7 +76,7 @@
   import ExploreData from "./_ExploreData.svelte";
 
   import { DL_Cosmos, DL_Calflod5m, DL_Calflod50m } from "./_constants";
-  import { getRasterMetaData, toBBoxPolygon } from "./_data";
+  import { getRasterMetaData } from "./_data";
 
   import { isFetchingStore, datasetStore } from "../_common/stores";
   import {
@@ -130,19 +130,12 @@
   async function update(bbox, scenario, timeFrame) {
     if (!appReady || !bbox) return;
     const sources = [DL_Cosmos, DL_Calflod5m, DL_Calflod50m];
-    let bboxGeom;
-    try {
-      bboxGeom = JSON.stringify(toBBoxPolygon(bbox).geometry);
-    } catch (error) {
-      console.error(error);
-      logException(error);
-    }
     isFetchingStore.set(true);
     try {
       (
         await Promise.all(
           sources.map((source) =>
-            getRasterMetaData(scenario, source, timeFrame, bboxGeom)
+            getRasterMetaData(scenario, source, timeFrame, bbox)
           )
         )
       ).forEach(({ results }, index) => {

--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -79,12 +79,7 @@
   import { DL_Cosmos, DL_Calflod5m, DL_Calflod50m } from "./_constants";
   import { getRasterMetaData, toBBoxPolygon } from "./_data";
 
-  import {
-    locationStore,
-    isFetchingStore,
-    datasetStore,
-    unitsStore,
-  } from "../_common/stores";
+  import { isFetchingStore, datasetStore } from "../_common/stores";
   import {
     floodScenarioStore,
     timeFrameStore,
@@ -113,7 +108,6 @@
     }
   };
 
-  const { location, boundary } = locationStore;
   const { bbox } = mapBBoxStore;
   const { tfTileLabel } = timeFrameStore;
 
@@ -124,8 +118,6 @@
   if (process.env.NODE_ENV !== "production") {
     logStores(
       floodScenarioStore,
-      location,
-      boundary,
       timeFrameStore,
       dataLayersStore,
       isFetchingStore,
@@ -169,22 +161,9 @@
     }
   }
 
-  async function initApp({
-    lat,
-    lng,
-    boundaryId,
-    imperial,
-    floodScenario,
-    timeFrame,
-  }) {
+  async function initApp({ floodScenario, timeFrame }) {
     floodScenarioStore.set(floodScenario);
     timeFrameStore.set(timeFrame);
-    unitsStore.set({ imperial });
-    const addresses = await reverseGeocode(`${lng}, ${lat}`);
-    const nearest = addresses.features[0];
-    const loc = await getFeature(nearest, boundaryId);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundaryId);
   }
 
   onMount(async () => {


### PR DESCRIPTION
This PR removes dead code and cleans some things up in the SLR CIS tool.
- for cal-adapt api calls for `/rstores` `bbintersects` query param, use envelope instead of geojson 
- remove dep `@turf/bbox-polygon`
- remove unused Svelte stores
- make `MapLayerHandler` instances non-reactive