### PR TITLE
MapLayerHandler: update setting of layer & source ids

### DIFF
--- a/src/components/tools/Map/MapLayerHandler.js
+++ b/src/components/tools/Map/MapLayerHandler.js
@@ -31,8 +31,8 @@ export class MapLayerHandler {
     return `${id}-source`;
   }
 
-  _getLayerId(id, index = 0) {
-    return `${id}-${index}-layer`;
+  _getLayerId(id) {
+    return `${id}-layer`;
   }
 
   _getSourceDef(value) {
@@ -96,9 +96,9 @@ export class MapLayerHandler {
     }
   }
 
-  addMapLayer({ id, asset, visibility, paintProps, index }) {
-    const layerId = this._getLayerId(id, index);
-    const sourceId = this._getSourceId(layerId);
+  addMapLayer({ id, asset, visibility, paintProps }) {
+    const layerId = this._getLayerId(id);
+    const sourceId = this._getSourceId(id);
     const source = this._getSourceDef(asset);
     const layer = this._getLayerDef(layerId, sourceId, paintProps, {
       visibility,
@@ -107,9 +107,9 @@ export class MapLayerHandler {
     this._addLayer(layerId, layer, this.beforeId);
   }
 
-  removeMapLayer(id, index) {
-    const layerId = this._getLayerId(id, index);
-    const sourceId = this._getSourceId(layerId);
+  removeMapLayer(id) {
+    const layerId = this._getLayerId(id);
+    const sourceId = this._getSourceId(id);
     this._removeLayer(layerId);
     this._removeSource(sourceId);
   }

--- a/src/components/tools/Map/MapLayerHandler.spec.js
+++ b/src/components/tools/Map/MapLayerHandler.spec.js
@@ -58,7 +58,7 @@ describe("MapLayerHandler", () => {
   test("getLayerId", () => {
     const mapLayerHandler = getMlhInstance();
     const result = mapLayerHandler._getLayerId("foo");
-    expect(result).toEqual("foo-0-layer");
+    expect(result).toEqual("foo-layer");
   });
 
   test("getSourceDef: tile url", () => {
@@ -146,9 +146,8 @@ describe("MapLayerHandler", () => {
       paintProps: {
         "raster-opacity": 0.5,
       },
-      index: 1,
     });
-    expect(mapLayerHandler._addSource).toBeCalledWith("my-1-layer-source", {
+    expect(mapLayerHandler._addSource).toBeCalledWith("my-source", {
       tiles: ["https://tiles.com/{z}/{x}/{y}.png"],
       tileSize: 256,
       type: "raster",
@@ -165,13 +164,12 @@ describe("MapLayerHandler", () => {
       paintProps: {
         "raster-opacity": 0.5,
       },
-      index: 1,
     });
     expect(mapLayerHandler._addLayer).toBeCalledWith(
-      "my-1-layer",
+      "my-layer",
       {
-        id: "my-1-layer",
-        source: "my-1-layer-source",
+        id: "my-layer",
+        source: "my-source",
         type: "raster",
         paint: {
           "raster-opacity": 0.5,
@@ -187,15 +185,15 @@ describe("MapLayerHandler", () => {
   test("removeMapLayer: removeLayer", () => {
     const mapLayerHandler = getMlhInstance();
     mapLayerHandler._removeLayer = jest.fn();
-    mapLayerHandler.removeMapLayer("my", 1);
-    expect(mapLayerHandler._removeLayer).toBeCalledWith("my-1-layer");
+    mapLayerHandler.removeMapLayer("my");
+    expect(mapLayerHandler._removeLayer).toBeCalledWith("my-layer");
   });
 
   test("removeMapLayer: removeSource", () => {
     const mapLayerHandler = getMlhInstance();
     mapLayerHandler._removeSource = jest.fn();
-    mapLayerHandler.removeMapLayer("my", 1);
-    expect(mapLayerHandler._removeSource).toBeCalledWith("my-1-layer-source");
+    mapLayerHandler.removeMapLayer("my");
+    expect(mapLayerHandler._removeSource).toBeCalledWith("my-source");
   });
 
   test("removeMapRef", () => {


### PR DESCRIPTION
Cleans up how the `MapLayerHandler` utility class handles creating ids for MapBoxGLJS's sources and layers.