### PR TITLE
dev chore: update deploy script for netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will first run `sapper export` and then transfer the output to the appropri
 
 ### Deploying to Netlify
 
-You may deploy a local build to be hosted on [Netlify](https://netlify.com) for sharing a new feature or bugfix in isolation.
+You may deploy a local build to be hosted on [Netlify](https://netlify.com) for sharing a new feature or bug fix in isolation.
 
 First install the [Netlify CLI tools](https://cli.netlify.com/):
 
@@ -53,10 +53,10 @@ netlify login
 Set the appropriate environment variables prior to running the deploy script:
 
 ```bash
-# the netlify personal access token
-export NETLIFY_AUTH_TOKEN="xxx"
-# name of the subdomain for the deployment
-export NETLIFY_ALIAS="my-branch-name"
+# the netlify personal access token:
+export NETLIFY_AUTH_TOKEN="xxxxxxxxx"
+# the subdomain for the deployment, e.g.
+export NETLIFY_ALIAS="bug-fix-abc"
 ```
 
 And then deploy as follows:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,37 @@ npm run deploy-dev
 
 This will first run `sapper export` and then transfer the output to the appropriate location on the Cal-Adapt webserver.
 
+### Deploying to Netlify
+
+You may deploy a local build to be hosted on [Netlify](https://netlify.com) for sharing a new feature or bugfix in isolation.
+
+First install the [Netlify CLI tools](https://cli.netlify.com/):
+
+```bash
+npm install netlify-cli -g
+```
+
+Then log-in to Netlify:
+
+```bash
+netlify login
+```
+
+Set the appropriate environment variables prior to running the deploy script:
+
+```bash
+# the netlify personal access token
+export NETLIFY_AUTH_TOKEN="xxx"
+# name of the subdomain for the deployment
+export NETLIFY_ALIAS="my-branch-name"
+```
+
+And then deploy as follows:
+
+```
+npm run deploy-netlify
+```
+
 ### Viewing the build locally prior to deploying
 
 If you would like to view the build locally prior to deploying, first create the build without transfering it to the server:

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -115,12 +115,11 @@ async function deployDev() {
 async function deployNetlify() {
   try {
     await sapperExport();
-    await $`netlify deploy 
-      --dir ${SAPPER_EXPORT_DIR}
-      --auth $NETLIFY_AUTH_TOKEN
-      --alias $NETLIFY_ALIAS
-      --open
-      `;
+    await $`netlify deploy \
+      --dir ${SAPPER_EXPORT_DIR}\
+      --auth $NETLIFY_AUTH_TOKEN\
+      --alias $NETLIFY_ALIAS\
+      --open`;
     await $`exit 0`;
   } catch (error) {
     handleError(error);

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -74,8 +74,8 @@ async function usage(message) {
 }
 
 async function handleError(error) {
-  console.log(error.message);
-  await $`exit 1`;
+  console.log(`Error: ${error.message}`);
+  process.exit(1);
 }
 
 async function sapperExport() {

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -117,6 +117,12 @@ async function deployDev() {
 }
 
 async function deployNetlify() {
+  if (!process.env.NETLIFY_AUTH_TOKEN || !process.env.NETLIFY_ALIAS) {
+    throw new Error(
+      "Deploying to Netlify requires setting environment variables: $NETLIFY_AUTH_TOKEN and $NETLIFY_ALIAS"
+    );
+  }
+
   try {
     await sapperExport();
     await $`netlify deploy \

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -60,8 +60,12 @@ async function usage(message) {
   if (message) {
     console.log(message);
   }
-  console.log("Usage: zx deploy.mjs --location=<string> --transfer=<boolean> --build=<boolean>");
-  console.log("--location is required; --transfer & --build are optional, both default to true");
+  console.log(
+    "Usage: zx deploy.mjs --location=<string> --transfer=<boolean> --build=<boolean>"
+  );
+  console.log(
+    "--location is required; --transfer & --build are optional, both default to true"
+  );
   await $`exit 0`;
 }
 

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -153,7 +153,7 @@ function setEnvProd() {
 }
 
 function setEnvNetlify() {
-  process.env.NODE_ENV = "development";
+  process.env.NODE_ENV = "production";
   process.env.DEPLOY = "netlify";
 }
 

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -115,7 +115,12 @@ async function deployDev() {
 async function deployNetlify() {
   try {
     await sapperExport();
-    await $`netlify deploy --dir=${SAPPER_EXPORT_DIR}`;
+    await $`netlify deploy 
+      --dir ${SAPPER_EXPORT_DIR}
+      --auth $NETLIFY_AUTH_TOKEN
+      --alias $NETLIFY_ALIAS
+      --open
+      `;
     await $`exit 0`;
   } catch (error) {
     handleError(error);

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -53,7 +53,11 @@ async function main() {
     allowBuild = false;
   }
 
-  await handleLocation(location);
+  try {
+    await handleLocation(location);
+  } catch (error) {
+    handleError(error);
+  }
 }
 
 async function usage(message) {


### PR DESCRIPTION
Fixes the `deploy-netlify` npm script:

- [x] Require netlify specific env variables to run script
  - access token: personal access auth token 
  - alias: the subdomain to use
- [x] set `NODE_ENV` to "production" when creating the build (otherwise the build will fail)
- [x] update the readme's deploy instructions to include Netlify specific env vars