### PR TITLE
Migrate lccs get wildfire data

### DIFF
--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -26,11 +26,11 @@ export function buildEnvelope(_data) {
     (d) => d.date.getUTCFullYear()
   );
   return dataArr.map(([key, value]) => {
-    const sortedArr = sort(value);
+    const arrExtent = extent(value);
     return {
       date: new Date(Date.UTC(key, 0, 1)),
-      min: sortedArr[0],
-      max: sortedArr[1],
+      min: arrExtent[0],
+      max: arrExtent[1],
     };
   });
 }

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -26,11 +26,11 @@ export function buildEnvelope(_data) {
     (d) => d.date.getUTCFullYear()
   );
   return dataArr.map(([key, value]) => {
-    const arrExtent = extent(value);
+    const [min, max] = extent(value);
     return {
       date: new Date(Date.UTC(key, 0, 1)),
-      min: arrExtent[0],
-      max: arrExtent[1],
+      min,
+      max,
     };
   });
 }

--- a/src/routes/tools/local-climate-change-snapshot/_constants.js
+++ b/src/routes/tools/local-climate-change-snapshot/_constants.js
@@ -27,10 +27,11 @@ export const AREABURNED_TIMESERIES_SLUG_EXP = "^fire_year.*bau";
 
 // The list of climate categories and indicators is in content/tools/local-climate-change-snapshot/
 export const DEFAULT_CLIMATE_CATEGORY = "temperature";
-export const DEFAULT_CLIMATE_INDICATOR = "tasmax";
+export const DEFAULT_CLIMATE_INDICATOR = "fire";
 // Precipitation indicator has values as rates e.g. mm/year
 // These should be converted to annual sum by multiplying by number of days in the year
 export const INDICATORS_WITH_VALUES_AS_RATES = ["pr"];
+export const INDICATORS_WITH_NO_ENSEMBLES = ["fire"];
 
 export const DEFAULT_INITIAL_CONFIG = {
   ...INITIAL_CONFIG,
@@ -50,6 +51,7 @@ export const COLOR_rcp45 = chroma(59, 153, 167);
 export const COLOR_rcp85 = chroma(131, 87, 170);
 export const COLOR_historical = chroma(170, 144, 60);
 
+export const SCENARIOS = ["historical", "rcp45", "rcp85"];
 export const OBSERVED = [
   {
     id: "livneh",

--- a/src/routes/tools/local-climate-change-snapshot/_constants.js
+++ b/src/routes/tools/local-climate-change-snapshot/_constants.js
@@ -18,8 +18,8 @@ export const DEFAULT_SNAPSHOT_SLUG_EXP = "^indicator_30y_.*ens32";
 // This search exp is used to separate timeseries with ens32avg from ens32min/ens32max
 // The envelope/range is created from the ensemble min & max & plotted as area,
 // while the ensemble avg is plotted as lines
-export const ENVELOPE_SEARCH_EXP = /min|max/;
-export const AVERAGE_SEARCH_EXP = /avg/;
+export const ENVELOPE_SEARCH_EXP = /ens32min|ens32max/;
+export const AVERAGE_SEARCH_EXP = /ens32avg/;
 /** Chart and Table data for the Area Burned indicator is assembled from the 4 GCMs.
  * There is no ensemble equivalent in the API.
  **/
@@ -56,7 +56,6 @@ export const OBSERVED = [
     id: "livneh",
     label: "Observed",
     color: COLOR_livneh.hex(),
-    type: "line",
   },
 ];
 export const SCENARIOS = [
@@ -64,19 +63,16 @@ export const SCENARIOS = [
     id: "rcp45",
     label: "Medium Emissions (RCP 4.5)",
     color: COLOR_rcp45.hex(),
-    type: "line",
   },
   {
     id: "rcp85",
     label: "High Emissions (RCP 8.5)",
     color: COLOR_rcp85.hex(),
-    type: "line",
   },
   {
     id: "historical",
     label: "Modeled Historical",
     color: COLOR_historical.hex(),
-    type: "line",
   },
 ];
 export const SCENARIO_RANGES = [
@@ -84,18 +80,15 @@ export const SCENARIO_RANGES = [
     id: "rcp45_range",
     label: "Medium Emissions Range",
     color: COLOR_rcp45.alpha(0.3).hex(),
-    type: "area",
   },
   {
     id: "rcp85_range",
     label: "High Emissions Range",
     color: COLOR_rcp85.alpha(0.3).hex(),
-    type: "area",
   },
   {
     id: "historical_range",
     label: "Modeled Historical Range",
     color: COLOR_historical.alpha(0.3).hex(),
-    type: "area",
   },
 ];

--- a/src/routes/tools/local-climate-change-snapshot/_constants.js
+++ b/src/routes/tools/local-climate-change-snapshot/_constants.js
@@ -51,45 +51,51 @@ export const COLOR_rcp45 = chroma(59, 153, 167);
 export const COLOR_rcp85 = chroma(131, 87, 170);
 export const COLOR_historical = chroma(170, 144, 60);
 
-export const SCENARIOS = ["historical", "rcp45", "rcp85"];
 export const OBSERVED = [
   {
     id: "livneh",
     label: "Observed",
     color: COLOR_livneh.hex(),
+    type: "line",
   },
 ];
-export const SERIES = [
+export const SCENARIOS = [
   {
     id: "rcp45",
     label: "Medium Emissions (RCP 4.5)",
     color: COLOR_rcp45.hex(),
+    type: "line",
   },
   {
     id: "rcp85",
     label: "High Emissions (RCP 8.5)",
     color: COLOR_rcp85.hex(),
+    type: "line",
   },
   {
     id: "historical",
     label: "Modeled Historical",
     color: COLOR_historical.hex(),
+    type: "line",
   },
 ];
-export const RANGES = [
+export const SCENARIO_RANGES = [
   {
     id: "rcp45_range",
     label: "Medium Emissions Range",
     color: COLOR_rcp45.alpha(0.3).hex(),
+    type: "area",
   },
   {
     id: "rcp85_range",
     label: "High Emissions Range",
     color: COLOR_rcp85.alpha(0.3).hex(),
+    type: "area",
   },
   {
     id: "historical_range",
     label: "Modeled Historical Range",
     color: COLOR_historical.alpha(0.3).hex(),
+    type: "area",
   },
 ];

--- a/src/routes/tools/local-climate-change-snapshot/_constants.js
+++ b/src/routes/tools/local-climate-change-snapshot/_constants.js
@@ -31,6 +31,8 @@ export const DEFAULT_CLIMATE_INDICATOR = "tasmax";
 // Precipitation indicator has values as rates e.g. mm/year
 // These should be converted to annual sum by multiplying by number of days in the year
 export const INDICATORS_WITH_VALUES_AS_RATES = ["pr"];
+// Area Burned indicator has no pre-calculated ensembles
+// All data for table and chart is assembled from 4 models & 2 scenarios
 export const INDICATORS_WITH_NO_ENSEMBLES = ["fire"];
 
 export const DEFAULT_INITIAL_CONFIG = {

--- a/src/routes/tools/local-climate-change-snapshot/_constants.js
+++ b/src/routes/tools/local-climate-change-snapshot/_constants.js
@@ -18,8 +18,8 @@ export const DEFAULT_SNAPSHOT_SLUG_EXP = "^indicator_30y_.*ens32";
 // This search exp is used to separate timeseries with ens32avg from ens32min/ens32max
 // The envelope/range is created from the ensemble min & max & plotted as area,
 // while the ensemble avg is plotted as lines
-export const ENVELOPE_SEARCH_EXP = /ens32min|ens32max/;
-export const AVERAGE_SEARCH_EXP = /ens32avg/;
+export const ENVELOPE_SEARCH_EXP = /min|max/;
+export const AVERAGE_SEARCH_EXP = /avg/;
 /** Chart and Table data for the Area Burned indicator is assembled from the 4 GCMs.
  * There is no ensemble equivalent in the API.
  **/
@@ -27,7 +27,7 @@ export const AREABURNED_TIMESERIES_SLUG_EXP = "^fire_year.*bau";
 
 // The list of climate categories and indicators is in content/tools/local-climate-change-snapshot/
 export const DEFAULT_CLIMATE_CATEGORY = "temperature";
-export const DEFAULT_CLIMATE_INDICATOR = "fire";
+export const DEFAULT_CLIMATE_INDICATOR = "tasmax";
 // Precipitation indicator has values as rates e.g. mm/year
 // These should be converted to annual sum by multiplying by number of days in the year
 export const INDICATORS_WITH_VALUES_AS_RATES = ["pr"];

--- a/src/routes/tools/local-climate-change-snapshot/_data.js
+++ b/src/routes/tools/local-climate-change-snapshot/_data.js
@@ -114,6 +114,7 @@ export async function getProjections({
   searchStr,
 }) {
   try {
+    if (!searchStr) return [];
     const { indicatorId, isAnnualRate } = config;
     const exp = searchStr.replace("indicator", indicatorId);
     const urls = await fetchUrls(exp);

--- a/src/routes/tools/local-climate-change-snapshot/_data.js
+++ b/src/routes/tools/local-climate-change-snapshot/_data.js
@@ -2,6 +2,7 @@
 import config from "~/helpers/api-config";
 import { handleXHR, fetchData, transformResponse } from "~/helpers/utilities";
 import { convertAnnualRateToSum } from "../_common/helpers";
+import { slugRegExp } from "./_helpers";
 
 // Constants
 import { OBSERVED_FILTER_YEAR } from "../_common/constants";
@@ -46,14 +47,20 @@ const fetchEvents = async ({
   if (error) {
     throw new Error(error.message);
   }
-  // Add slug to keep track of which ensemble series the data comes from
-  const slug = url.split("series/")[1];
   const values = isAnnualRate
     ? transformResponse(response).map((d) => ({
         date: d.date,
         value: convertAnnualRateToSum(d),
       }))
     : transformResponse(response);
+  // Add slug to keep track of which ensemble series the data comes from
+  let slug;
+  const regExpResult = slugRegExp.exec(url);
+  if (!regExpResult) {
+    throw new Error("slug not found in url");
+  } else {
+    slug = regExpResult[0];
+  }
   // For livneh, remove data values after 2006
   // because there are QA/QC issues with the data
   if (slug.includes("livneh")) {

--- a/src/routes/tools/local-climate-change-snapshot/_data.js
+++ b/src/routes/tools/local-climate-change-snapshot/_data.js
@@ -1,15 +1,3 @@
-import {
-  group,
-  groups,
-  merge,
-  mean,
-  rollups,
-  min,
-  max,
-  extent,
-  flatGroup,
-} from "d3-array";
-
 // Helpers
 import config from "~/helpers/api-config";
 import { handleXHR, fetchData, transformResponse } from "~/helpers/utilities";
@@ -17,12 +5,7 @@ import { convertAnnualRateToSum } from "../_common/helpers";
 
 // Constants
 import { OBSERVED_FILTER_YEAR } from "../_common/constants";
-import {
-  DEFAULT_OBSERVED_SLUG_EXP,
-  OBSERVED,
-  SCENARIOS,
-  SCENARIO_RANGES,
-} from "./_constants";
+import { DEFAULT_OBSERVED_SLUG_EXP, OBSERVED, SCENARIOS } from "./_constants";
 
 const { apiEndpoint } = config.env.production;
 
@@ -107,9 +90,9 @@ export async function getObserved({
     );
     const data = await Promise.all(promises);
     return data.map(({ slug, values }) => {
-      // Add additional props for series (e.g. id, color, label, type)
+      // Add additional props for timeseries (e.g. id, color, label)
       const props = OBSERVED.find(({ id }) => slug.includes(id));
-      return { ...props, values };
+      return { slug, ...props, values };
     });
   } catch (error) {
     throw new Error(error.message);
@@ -139,9 +122,9 @@ export async function getProjections({
     );
     const data = await Promise.all(promises);
     return data.map(({ slug, values }) => {
-      // Add additional props for timeseries (e.g. id, color, label, type)
+      // Add additional props for timeseries (e.g. id, color, label)
       const props = SCENARIOS.find(({ id }) => slug.includes(id));
-      return { ...props, values };
+      return { slug, ...props, values };
     });
   } catch (error) {
     throw new Error(error.message);

--- a/src/routes/tools/local-climate-change-snapshot/_helpers.js
+++ b/src/routes/tools/local-climate-change-snapshot/_helpers.js
@@ -1,0 +1,71 @@
+import {
+  group,
+  groups,
+  merge,
+  mean,
+  rollups,
+  min,
+  max,
+  extent,
+} from "d3-array";
+
+// Helpers
+import { buildEnvelope, convertAnnualRateToSum } from "../_common/helpers";
+
+// Constants
+import { DEFAULT_STAT_PERIODS } from "../_common/constants";
+import {
+  ENVELOPE_SEARCH_EXP,
+  AVERAGE_SEARCH_EXP,
+  OBSERVED,
+  SERIES,
+  RANGES,
+  SCENARIOS,
+} from "./_constants";
+
+/**
+ * Filter data to find timseries that correspond to ensemble min & max
+ * Add additional props (e.g. id, color, label, type)
+ * Group the ensemble min & max timeseries by id
+ * Create a new ensemble timeseries for envelope
+ * @param {array} - array of all timeseries
+ * @return {array} - ensemble timeseries with min & max values for 3 scenarios (historical, rcp45, rcp85)
+ */
+export const createRanges = (_data) => {
+  const rangeData = _data
+    .filter(({ slug }) => slug.search(ENVELOPE_SEARCH_EXP) > 0)
+    .map(({ slug, values }) => {
+      // id in the RANGES array are in the form "[scenario]_range". The slug
+      // only has [scenario] part. So use only part of the id to search
+      const props = RANGES.find(({ id }) => slug.includes(id.split("_")[0]));
+      return { ...props, type: "area", values };
+    });
+  // Group the ensemble min & max for each scenario
+  const groupByIds = Array.from(group(rangeData, (d) => d.id));
+  return groupByIds.map(([groupId, _arrays]) => {
+    const values = merge(_arrays.map(({ values }) => values));
+    const envelope = buildEnvelope(values);
+    // return props common to both ensemble min & max (id, label, color, type)
+    // and a new values array
+    return {
+      ..._arrays[0],
+      values: envelope,
+    };
+  });
+};
+
+/**
+ * Filter data to find timseries that correspond to ensemble avg
+ * Add additional props (e.g. id, color, label, type)
+ * @param {array} - array of all timeseries
+ * @return {array} - average timeseries for 3 scenarios (historical, rcp45, rcp85)
+ */
+export const createAverages = (_data) => {
+  const avgData = _data.filter(
+    ({ slug }) => slug.search(AVERAGE_SEARCH_EXP) > 0
+  );
+  return avgData.map(({ slug, values }) => {
+    const props = SERIES.find(({ id }) => slug.includes(id));
+    return { ...props, type: "line", values };
+  });
+};

--- a/src/routes/tools/local-climate-change-snapshot/_helpers.js
+++ b/src/routes/tools/local-climate-change-snapshot/_helpers.js
@@ -12,6 +12,12 @@ import {
   SCENARIO_RANGES,
 } from "./_constants";
 
+// Regular Expression that matches the entirety of a series slug for the LCCS tool.
+// For example, in the following string:
+// "https://api.cal-adapt.org/api/series/tasmax_30y_ens32min_rcp85/"
+// this regex will match "tasmax_30y_ens32min_rcp85"
+export const slugRegExp = /(?<=\/)[\w]{7,}(?=\/)/;
+
 /**
  * Observed data does not need to be averaged
  * Add extra prop for plotting (type)

--- a/src/routes/tools/local-climate-change-snapshot/_helpers.js
+++ b/src/routes/tools/local-climate-change-snapshot/_helpers.js
@@ -8,7 +8,6 @@ import { DEFAULT_STAT_PERIODS } from "../_common/constants";
 import {
   ENVELOPE_SEARCH_EXP,
   AVERAGE_SEARCH_EXP,
-  OBSERVED,
   SCENARIOS,
   SCENARIO_RANGES,
 } from "./_constants";

--- a/src/routes/tools/local-climate-change-snapshot/_helpers.js
+++ b/src/routes/tools/local-climate-change-snapshot/_helpers.js
@@ -1,16 +1,7 @@
-import {
-  group,
-  groups,
-  merge,
-  mean,
-  rollups,
-  min,
-  max,
-  extent,
-} from "d3-array";
+import { groups, merge, mean } from "d3-array";
 
 // Helpers
-import { buildEnvelope, convertAnnualRateToSum } from "../_common/helpers";
+import { buildEnvelope } from "../_common/helpers";
 
 // Constants
 import { DEFAULT_STAT_PERIODS } from "../_common/constants";
@@ -18,54 +9,208 @@ import {
   ENVELOPE_SEARCH_EXP,
   AVERAGE_SEARCH_EXP,
   OBSERVED,
-  SERIES,
-  RANGES,
   SCENARIOS,
+  SCENARIO_RANGES,
 } from "./_constants";
 
 /**
- * Filter data to find timseries that correspond to ensemble min & max
- * Add additional props (e.g. id, color, label, type)
- * Group the ensemble min & max timeseries by id
- * Create a new ensemble timeseries for envelope
- * @param {array} - array of all timeseries
- * @return {array} - ensemble timeseries with min & max values for 3 scenarios (historical, rcp45, rcp85)
+ * Observed data does not need to be averaged
+ * Add extra prop for plotting (type)
+ * @param {array} - all observed timeseries
+ * @return {array} - all observed timeseries
  */
-export const createRanges = (_data) => {
-  const rangeData = _data
-    .filter(({ slug }) => slug.search(ENVELOPE_SEARCH_EXP) > 0)
-    .map(({ slug, values }) => {
-      // id in the RANGES array are in the form "[scenario]_range". The slug
-      // only has [scenario] part. So use only part of the id to search
-      const props = RANGES.find(({ id }) => slug.includes(id.split("_")[0]));
-      return { ...props, type: "area", values };
-    });
-  // Group the ensemble min & max for each scenario
-  const groupByIds = Array.from(group(rangeData, (d) => d.id));
-  return groupByIds.map(([groupId, _arrays]) => {
-    const values = merge(_arrays.map(({ values }) => values));
-    const envelope = buildEnvelope(values);
-    // return props common to both ensemble min & max (id, label, color, type)
-    // and a new values array
-    return {
-      ..._arrays[0],
-      values: envelope,
-    };
+const createObservedSeries = (_data) => {
+  return _data.map((series) => {
+    const { slug, ...rest } = series;
+    return { ...rest, type: "line" };
   });
 };
 
 /**
  * Filter data to find timseries that correspond to ensemble avg
- * Add additional props (e.g. id, color, label, type)
+ * Add extra prop for plotting (type)
  * @param {array} - array of all timeseries
  * @return {array} - average timeseries for 3 scenarios (historical, rcp45, rcp85)
  */
-export const createAverages = (_data) => {
-  const avgData = _data.filter(
-    ({ slug }) => slug.search(AVERAGE_SEARCH_EXP) > 0
+const createAverages = (_data) => {
+  return _data
+    .filter(({ slug }) => slug.search(AVERAGE_SEARCH_EXP) > 0)
+    .map((series) => {
+      const { slug, ...rest } = series;
+      return { ...rest, type: "line" };
+    });
+};
+
+/**
+ * Filter data to find timseries that correspond to ensemble min & max
+ * Group the ensemble min & max timeseries by id
+ * Create a new ensemble timeseries for envelope
+ * Add extra prop for plotting (type)
+ * @param {array} - array of all timeseries
+ * @return {array} - ensemble timeseries with min & max values for 3 scenarios (historical, rcp45, rcp85)
+ */
+const createRanges = (_data) => {
+  const rangeData = _data.filter(
+    ({ slug }) => slug.search(ENVELOPE_SEARCH_EXP) > 0
   );
-  return avgData.map(({ slug, values }) => {
-    const props = SERIES.find(({ id }) => slug.includes(id));
-    return { ...props, type: "line", values };
+  // Group the ensemble min & max for each scenario
+  const groupByIds = groups(rangeData, (d) => d.id);
+  return groupByIds.map(([groupId, _arrays]) => {
+    const values = merge(_arrays.map(({ values }) => values));
+    const envelope = buildEnvelope(values);
+    // Find matching props for scenario range
+    // The ranges are plotted as areas and have different id, color & label props
+    const props = SCENARIO_RANGES.find(({ id }) => id.includes(groupId));
+    return {
+      ...props,
+      values: envelope,
+      type: "area",
+    };
   });
 };
+
+/**
+ * Calculate 30 year average for each scenario & period combination
+ * @param {array} scenarios
+ * @param {array} periods
+ * @return {array} scenario & period combinations that have a valid 30 year avg value
+ */
+function calc30yAvgByPeriod(series, periods = DEFAULT_STAT_PERIODS) {
+  const data = series.map((d) => {
+    const { values, id: scenarioId, label: scenarioLabel } = d;
+    const dataByPeriods = periods.map((period) => {
+      const { id: periodId, label: periodLabel, start, end } = period;
+      const filteredValues = values.filter(
+        ({ date }) =>
+          date.getUTCFullYear() >= start && date.getUTCFullYear() <= end
+      );
+      let avg = null;
+      if (filteredValues.length) {
+        avg = mean(filteredValues, (d) => d.value);
+      }
+      return { periodId, periodLabel, scenarioId, scenarioLabel, avg };
+    });
+    return [...dataByPeriods];
+  });
+  return merge(data).filter(({ avg }) => avg !== null);
+}
+
+/**
+ * Map 30 year extent for each scenario & period combination
+ * @param {array} scenarios
+ * @param {array} periods
+ * @return {array} scenario & period combination that have a valid 30 year extent
+ */
+function map30yExtentToPeriod(scenarios, periods = DEFAULT_STAT_PERIODS) {
+  const data = scenarios.map((d) => {
+    const { values, id: scenarioId, label: scenarioLabel } = d;
+    const dataByPeriods = periods.map((period) => {
+      const { id: periodId, label: periodLabel, start, end } = period;
+      const filteredValues = values.filter(
+        ({ date }) =>
+          date.getUTCFullYear() >= start && date.getUTCFullYear() <= end
+      );
+      let min = null;
+      let max = null;
+      if (filteredValues.length && filteredValues.length === 1) {
+        min = filteredValues[0].min;
+        max = filteredValues[0].max;
+      }
+      return { periodId, periodLabel, scenarioId, scenarioLabel, min, max };
+    });
+    return [...dataByPeriods];
+  });
+  return merge(data).filter(({ min, max }) => min !== null && max !== null);
+}
+
+/**
+ * Assemble annual timeseries for observed and projections for the the Chart component
+ * There are 7 timeseries for all indicators except `fire`
+ * `fire` does not have any Observed data
+ * 1. Observed
+ * 2. Modeled Historical Scenario
+ * 3. RCP 4.5 Scenario
+ * 4. RCP 8.5 Scenario
+ * 5. Modeled Historical Scenario Envelope/Range
+ * 6. RCP 4.5 Scenario Envelope/Range
+ * 7. RCP 8.5 Scenario Envelope/Range
+ **/
+export function getDataForChart(_data) {
+  const { observed, projections } = _data;
+  const observedSeries = createObservedSeries(observed);
+  const averages = createAverages(projections);
+  const ranges = createRanges(projections);
+  return [...observedSeries, ...averages, ...ranges];
+}
+
+/**
+ * Calculate 30 year stats for observed and ensemble projections by period.
+ * This data is used for the Table component.
+ * There are 6 possible scenario & period combinations that have valid values
+ * except `fire` which does not have any Observed data:
+ * 1. Observed & Baseline Period
+ * 2. Modeled Historical Scenario & Baseline Period
+ * 3. RCP 4.5 Scenario & Mid-Century Period
+ * 4. RCP 4.5 Scenario & End-Century Period
+ * 5. RCP 8.5 Scenario & Mid-Century Period
+ * 6. RCP 8.5 Scenario & End-Century Period
+ *
+ * The 30 year stats calculated are:
+ * avg - average
+ * change - change from modeled baseline
+ * min - 30 year minimum
+ * max - 30 year maximum
+ *
+ * Calculation method for all indicators except `fire`:
+ * avg - 30 year average is calculated using ensemble average values
+ * change - change is difference of average from modeled baseline average
+ * min - 30 year minimum is pre-calculated and fetched from the API
+ * max - 30 year maximum is pre-calculated and fetched from the API
+ *
+ * Calculation method for `fire`:
+ * avg - 30 year average is calculated using ensemble average values
+ * change - change is difference of average from modeled baseline average
+ * min - 30 year minimum is pre-calculated and fetched from the API
+ * max - 30 year maximum is pre-calculated and fetched from the API
+ **/
+export function getDataForSnapshot(_data) {
+  const { observed, projections, projections30y } = _data;
+
+  //** Calculate 30 year average for #1 combination
+
+  // There is no change, min or max for observed data
+  const observedStats = calc30yAvgByPeriod(observed);
+
+  //** Calculate 30 year stats for #2-#6 combinations
+
+  // Get the annual ensemble average for each scenario
+  const ensembleAverages = projections.filter(
+    ({ slug }) => slug.search(AVERAGE_SEARCH_EXP) > 0
+  );
+  // Calculate 30 year average
+  const data30yAvg = calc30yAvgByPeriod(ensembleAverages);
+
+  // Create ensemble range for each scenario
+  // using 30 year pre-calculated extents from the API
+  const ensembleRanges = createRanges(projections30y);
+  // Map 30 year pre-calculated extents for each scenario to the periods
+  const data30yExtents = map30yExtentToPeriod(ensembleRanges);
+
+  // Find the modeled baseline 30 year average (combination #2)
+  const modeledBaseline = data30yAvg.find(
+    ({ periodId }) => periodId === "baseline"
+  );
+  // Combine the 30y avg & 30y extent
+  // Calculate change from baseline by subtracting 30 year average for each combination
+  // The change from baseline value for combination #2 will obviously be 0. This is represented by
+  // a "-" in the Snapshot table.
+  const projectionStats = data30yAvg.map((d) => {
+    const { scenarioId, periodId, avg } = d;
+    const change = modeledBaseline ? avg - modeledBaseline.avg : null;
+    const match = data30yExtents.find(
+      (c) => c.scenarioId.includes(scenarioId) && c.periodId === periodId
+    );
+    return { ...match, ...d, change };
+  });
+  return [...observedStats, ...projectionStats];
+}

--- a/src/routes/tools/local-climate-change-snapshot/_helpers.js
+++ b/src/routes/tools/local-climate-change-snapshot/_helpers.js
@@ -176,13 +176,11 @@ export function getDataForChart(_data) {
 export function getDataForSnapshot(_data) {
   const { observed, projections, projections30y } = _data;
 
-  //** Calculate 30 year average for #1 combination
-
+  //** Calculate 30 year average for #1
   // There is no change, min or max for observed data
   const observedStats = calc30yAvgByPeriod(observed);
 
-  //** Calculate 30 year stats for #2-#6 combinations
-
+  //** Calculate 30 year stats for #2-#6
   // Get the annual ensemble average for each scenario
   const ensembleAverages = projections.filter(
     ({ slug }) => slug.search(AVERAGE_SEARCH_EXP) > 0

--- a/src/routes/tools/local-climate-change-snapshot/_store.js
+++ b/src/routes/tools/local-climate-change-snapshot/_store.js
@@ -1,4 +1,4 @@
-import { writable, derived } from "svelte/store";
+import { writable } from "svelte/store";
 import { makeCustomWritableStore } from "../_common/stores";
 import { getDataForChart, getDataForSnapshot } from "./_helpers";
 

--- a/src/routes/tools/local-climate-change-snapshot/_store.js
+++ b/src/routes/tools/local-climate-change-snapshot/_store.js
@@ -26,8 +26,15 @@ export const indicatorStore = writable(null);
  *    3. CanESM2
  *    4. HadGEM2-ES
  * projections30y = no data
+ *
+ * isEnsemble is true for all indicators except `fire`
  **/
-const DATA = { observed: null, projections: null, projections30y: null };
+const DATA = {
+  observed: null,
+  projections: null,
+  projections30y: null,
+  isEnsemble: true,
+};
 
 export const dataStore = makeCustomWritableStore(DATA, {
   name: "dataStore",
@@ -36,14 +43,14 @@ export const dataStore = makeCustomWritableStore(DATA, {
       name: "chartDataStore",
       getter: ($s) => {
         if (!$s.observed || !$s.projections) return null;
-        return getDataForChart($s);
+        return getDataForChart($s, $s.isEnsemble);
       },
     },
     {
       name: "snapshotDataStore",
       getter: ($s) => {
         if (!$s.projections || !$s.projections30y) return null;
-        return getDataForSnapshot($s);
+        return getDataForSnapshot($s, $s.isEnsemble);
       },
     },
   ],
@@ -69,6 +76,14 @@ export const dataStore = makeCustomWritableStore(DATA, {
       update: (store) => (_data) =>
         store.update((s) => {
           s.projections30y = _data;
+          return s;
+        }),
+    },
+    {
+      name: "setEnsembleFlag",
+      update: (store) => (bool) =>
+        store.update((s) => {
+          s.isEnsemble = bool;
           return s;
         }),
     },

--- a/src/routes/tools/local-climate-change-snapshot/_store.js
+++ b/src/routes/tools/local-climate-change-snapshot/_store.js
@@ -1,28 +1,34 @@
 import { writable, derived } from "svelte/store";
 import { makeCustomWritableStore } from "../_common/stores";
-import { calc30yAvgByPeriod, map30yExtentByPeriod } from "./_data";
+import { getDataForChart, getDataForSnapshot } from "./_helpers";
 
 export const categoryListStore = writable(null);
 export const indicatorListStore = writable(null);
 export const indicatorStore = writable(null);
 
+/**
+ * This custom dataStore stores the following data for all indicators except `fire`:
+ * observed = annual timeseries for observed (1)
+ * projections = annual timeseries for (9):
+ * 		1. Modeled Historical ensemble avg, min, max
+ * 		2. RCP 4.5 ensemble avg, min, max
+ * 		3. RCP 8.5 ensemble avg, min, max
+ * projections30y = 30 year ensemble data for (6):
+ * 		1. Modeled Historical min, max
+ * 		2. RCP 4.5 min, max
+ * 		3. RCP 8.5 min, max
+ *
+ * For `fire` indicator the data store inlcudes:
+ * observed = no data
+ * projections = annual timeseries for 4 priority models (4):
+ *    1. CNRM-CM5
+ *    2. MIROC5
+ *    3. CanESM2
+ *    4. HadGEM2-ES
+ * projections30y = no data
+ **/
 const DATA = { observed: null, projections: null, projections30y: null };
 
-/**
- * This custom dataStore stores the following data:
- * observed = annual livneh timeseries
- * projections = annual ensembles for
- * 		1. Modeled Historical average & range
- * 		2. RCP 4.5 average & range
- * 		3. RCP 8.5 average & range
- * projections30y = 30 year ensemble extents for
- * 		1. Modeled Historical Mid-Century & End-Century
- * 		2. RCP 4.5 Mid-Century & End-Century
- * 		3. RCP 8.5 Mid-Century & End-Century
- *
- * The data in observed & projections props are used for the Chart.
- * The data in projections30y is used in creating the snapshotProjectionsStore
- **/
 export const dataStore = makeCustomWritableStore(DATA, {
   name: "dataStore",
   getters: [
@@ -30,7 +36,14 @@ export const dataStore = makeCustomWritableStore(DATA, {
       name: "chartDataStore",
       getter: ($s) => {
         if (!$s.observed || !$s.projections) return null;
-        return [...$s.observed, ...$s.projections];
+        return getDataForChart($s);
+      },
+    },
+    {
+      name: "snapshotDataStore",
+      getter: ($s) => {
+        if (!$s.projections || !$s.projections30y) return null;
+        return getDataForSnapshot($s);
       },
     },
   ],
@@ -60,55 +73,4 @@ export const dataStore = makeCustomWritableStore(DATA, {
         }),
     },
   ],
-});
-
-/**
- * Calculate 30 year stats for 3 scenarios and 3 periods for the Snapshot table.
- * There are 5 possible combinations that have valid values:
- * 1. Modeled Historical Scenario & Baseline Period
- * 2. RCP 4.5 Scenario & Mid-Century Period
- * 3. RCP 4.5 Scenario & End-Century Period
- * 4. RCP 8.5 Scenario & Mid-Century Period
- * 5. RCP 8.5 Scenario & End-Century Period
- **/
-export const snapshotProjectionsStore = derived(dataStore, ($dataStore) => {
-  if (!$dataStore || !$dataStore.projections || !$dataStore.projections30y)
-    return;
-  // Get the annual ensemble average for each scenario
-  const ensembleAverages = $dataStore.projections.filter(
-    ({ id }) => !id.includes("range")
-  );
-  // Calculate 30 year average for the 5 valid scenario & period combinations
-  const data30yAvg = calc30yAvgByPeriod(ensembleAverages);
-  // Map 30 year extent for each scenario to the periods
-  const data30yExtent = map30yExtentByPeriod($dataStore.projections30y);
-
-  // Find the baseline 30 year average (combination #1)
-  const baseline = data30yAvg.find(
-    ({ scenarioId, periodId }) =>
-      scenarioId === "historical" && periodId === "baseline"
-  );
-
-  // Combine the 30y avg & 30y extent for the valid combinations
-  // Calculate change from baseline by subtracting 30 year average for each combination
-  // The change from baseline value for combination #1 will obviously be 0. This is represented by
-  // a "-" in the Snapshot table.
-  return data30yAvg.map((d) => {
-    const { scenarioId, periodId, avg } = d;
-    const change = baseline ? avg - baseline.avg : null;
-    const match = data30yExtent.find(
-      (c) => c.scenarioId.includes(scenarioId) && c.periodId === periodId
-    );
-    return { ...match, ...d, change };
-  });
-});
-
-/**
- * Calculate 30 year stats for observed data for the Snapshot Table.
- * There is only 1 possible combination that has valid values:
- * 1. Observed & Baseline Period
- **/
-export const snapshotObservedStore = derived(dataStore, ($dataStore) => {
-  if (!$dataStore || !$dataStore.observed) return;
-  return calc30yAvgByPeriod($dataStore.observed);
 });

--- a/src/routes/tools/local-climate-change-snapshot/explore.svelte
+++ b/src/routes/tools/local-climate-change-snapshot/explore.svelte
@@ -83,15 +83,16 @@
     console.groupEnd();
   }
 
-  $: if (
-    $chartDataStore &&
-    $snapshotObservedStore &&
-    $snapshotProjectionsStore
-  ) {
-    console.log("chart data", $chartDataStore);
-    console.log("snapshot table baseline", $snapshotObservedStore);
-    console.log("snapshot table projections", $snapshotProjectionsStore);
-  }
+  // $: if (
+  //   $chartDataStore &&
+  //   $snapshotObservedStore &&
+  //   $snapshotProjectionsStore
+  // ) {
+  //   console.log("chart data", $chartDataStore);
+  //   console.log("snapshot table baseline", $snapshotObservedStore);
+  //   console.log("snapshot table projections", $snapshotProjectionsStore);
+  // }
+  $: console.log("data", $dataStore);
 
   async function update() {
     if (!appReady) return;
@@ -124,6 +125,11 @@
         $indicatorStore.id === "fire"
           ? AREABURNED_TIMESERIES_SLUG_EXP
           : DEFAULT_PROJECTIONS_SLUG_EXP;
+      const snapshotSearchStr =
+        $indicatorStore.id === "fire"
+          ? AREABURNED_TIMESERIES_SLUG_EXP
+          : DEFAULT_SNAPSHOT_SLUG_EXP;
+
       const observed = await getObserved({ config, params, method });
       const projections = await getProjections({
         config,
@@ -137,7 +143,7 @@
         config,
         params,
         method,
-        searchStr: DEFAULT_SNAPSHOT_SLUG_EXP,
+        searchStr: snapshotSearchStr,
       });
       dataStore.setProjections30y(projections30y);
     } catch (error) {

--- a/src/routes/tools/local-climate-change-snapshot/explore.svelte
+++ b/src/routes/tools/local-climate-change-snapshot/explore.svelte
@@ -153,6 +153,9 @@
         method,
         searchStr: snapshotSearchStr,
       });
+      dataStore.setEnsembleFlag(
+        !INDICATORS_WITH_NO_ENSEMBLES.includes($indicatorStore.id)
+      );
       dataStore.setObserved(observed);
       dataStore.setProjections(projections);
       dataStore.setProjections30y(projections30y);

--- a/src/routes/tools/local-climate-change-snapshot/explore.svelte
+++ b/src/routes/tools/local-climate-change-snapshot/explore.svelte
@@ -56,8 +56,11 @@
   import {
     DEFAULT_INITIAL_CONFIG,
     DEFAULT_POLYGON_AGGREGATE_FUNCTION,
+    AREABURNED_POLYGON_AGGREGATE_FUNCTION,
     INDICATORS_WITH_VALUES_AS_RATES,
+    DEFAULT_PROJECTIONS_SLUG_EXP,
     DEFAULT_SNAPSHOT_SLUG_EXP,
+    AREABURNED_TIMESERIES_SLUG_EXP,
     DEFAULT_SWE_MONTH,
   } from "./_constants";
 
@@ -99,26 +102,42 @@
           $indicatorStore.id
         ),
       };
+
       // Get params object for querying the Cal-Adapt API
       // extra months param required for April SWE indicator
       const months = $indicatorStore.id === "swe" ? DEFAULT_SWE_MONTH : null;
+      const stat =
+        $indicatorStore.id === "fire"
+          ? AREABURNED_POLYGON_AGGREGATE_FUNCTION
+          : DEFAULT_POLYGON_AGGREGATE_FUNCTION;
       const { params, method } = getQueryParams({
         location: $location,
         boundary: $boundary,
         imperial: true,
-        stat: DEFAULT_POLYGON_AGGREGATE_FUNCTION,
+        stat,
         ...(months && { months }),
       });
+
       isFetchingStore.set(true);
+
+      const projectionsSearchStr =
+        $indicatorStore.id === "fire"
+          ? AREABURNED_TIMESERIES_SLUG_EXP
+          : DEFAULT_PROJECTIONS_SLUG_EXP;
       const observed = await getObserved({ config, params, method });
-      const projections = await getProjections({ config, params, method });
+      const projections = await getProjections({
+        config,
+        params,
+        method,
+        searchStr: projectionsSearchStr,
+      });
       dataStore.setObserved(observed);
       dataStore.setProjections(projections);
       const projections30y = await getProjections({
         config,
         params,
         method,
-        searhcStr: DEFAULT_SNAPSHOT_SLUG_EXP,
+        searchStr: DEFAULT_SNAPSHOT_SLUG_EXP,
       });
       dataStore.setProjections30y(projections30y);
     } catch (error) {

--- a/src/routes/tools/local-climate-change-snapshot/explore.svelte
+++ b/src/routes/tools/local-climate-change-snapshot/explore.svelte
@@ -32,7 +32,6 @@
   // Helpers
   import { logException } from "~/helpers/logging";
   import { getInitialConfig, setInitialLocation } from "../_common/helpers";
-  import { INITIAL_CONFIG } from "../_common/constants";
   import { getQueryParams, getProjections, getObserved } from "./_data";
 
   // Components


### PR DESCRIPTION
This PR includes code for fetching `fire` data for the Area Burned Indicator. To accommodate the creation of ensemble & snapshot from individual models for `fire`, the data fetching code for other indicators has been refactored.