### PR TITLE
SLR CIS: add map explainer text

### DIFF
--- a/content/tools/slr-coastal-inundation/map-explainer.md
+++ b/content/tools/slr-coastal-inundation/map-explainer.md
@@ -1,0 +1,3 @@
+This map shows data coverage extents for the two models at lower zoom
+levels (e.g. at the county and state level resolutions), zoom in to view
+the coastal inundation datasets.

--- a/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
@@ -118,6 +118,9 @@
     align-items: flex-start;
     flex-direction: column;
   }
+  .map-info-text {
+    max-width: 65ch;
+  }
 </style>
 
 {#if $isFetchingStore}
@@ -140,6 +143,11 @@
     class="block"
     style="background: var(--gray-20);"
   >
+    <p class="map-info-text">
+      This map shows data coverage extents for the two models at lower zoom
+      levels (e.g. at the county or state level resolutions), zoom in to view
+      the coastal inundation datasets.
+    </p>
     <div class="map-controls-container">
       <Legend
         title="Map Data Layers"

--- a/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
@@ -21,6 +21,7 @@
 
   export let learnMoreContent;
   export let mapStyle;
+  export let mapExplainer;
 
   const { timeFrame } = timeFrameStore;
   const { floodScenario } = floodScenarioStore;
@@ -119,7 +120,7 @@
     flex-direction: column;
   }
   .map-info-text {
-    max-width: 65ch;
+    max-width: 75ch;
   }
 </style>
 
@@ -143,11 +144,7 @@
     class="block"
     style="background: var(--gray-20);"
   >
-    <p class="map-info-text">
-      This map shows data coverage extents for the two models at lower zoom
-      levels (e.g. at the county or state level resolutions), zoom in to view
-      the coastal inundation datasets.
-    </p>
+    <div class="map-info-text">{@html mapExplainer}</div>
     <div class="map-controls-container">
       <Legend
         title="Map Data Layers"

--- a/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
@@ -119,8 +119,8 @@
     align-items: flex-start;
     flex-direction: column;
   }
-  .map-info-text {
-    max-width: 75ch;
+  .map-info-text-container :global(p) {
+    max-width: 70ch;
   }
 </style>
 
@@ -144,7 +144,7 @@
     class="block"
     style="background: var(--gray-20);"
   >
-    <div class="map-info-text">{@html mapExplainer}</div>
+    <div class="map-info-text-container">{@html mapExplainer}</div>
     <div class="map-controls-container">
       <Legend
         title="Map Data Layers"

--- a/src/routes/tools/slr-coastal-inundation/index.json.js
+++ b/src/routes/tools/slr-coastal-inundation/index.json.js
@@ -15,6 +15,10 @@ export function get(_req, res) {
       "slr-coastal-inundation",
       "learn-more-time-period"
     );
+    const mapExplainer = getToolContent(
+      "slr-coastal-inundation",
+      "map-explainer"
+    );
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(
       JSON.stringify({
@@ -24,6 +28,7 @@ export function get(_req, res) {
           mapLayers,
           timePeriod,
         },
+        mapExplainer,
       })
     );
   } catch (error) {

--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -28,7 +28,7 @@
       ["get-started", "faqs"].includes(d.slug)
     );
 
-    const { aboutContent, learnMoreContent } = await (
+    const { aboutContent, learnMoreContent, mapExplainer } = await (
       await this.fetch("tools/slr-coastal-inundation.json")
     ).json();
 
@@ -39,6 +39,7 @@
       helpItems,
       aboutContent,
       learnMoreContent,
+      mapExplainer,
     };
   }
 </script>
@@ -83,6 +84,7 @@
   export let helpItems;
   export let aboutContent;
   export let learnMoreContent;
+  export let mapExplainer;
 
   let appReady = false;
   let baseMapStyle;
@@ -207,6 +209,7 @@
     <ExploreData
       learnMoreContent="{learnMoreContent}"
       mapStyle="{baseMapStyle}"
+      mapExplainer="{mapExplainer}"
     />
   {:else}
     <Loading />


### PR DESCRIPTION
Adds the following map explainer text below the slippy map per the CEC request

> This map shows data coverage extents for the two models at lower zoom levels (e.g. at the county or state level resolutions), zoom in to view the coastal inundation datasets.