### PR TITLE
use sass media query mixins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "fast-deep-equal": "^3.1.3",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.0.0-rc.7",
+        "include-media": "^1.4.10",
         "install": "^0.13.0",
         "jspdf": "^2.3.1",
         "just-left-pad": "^2.1.0",
@@ -9188,6 +9189,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/include-media": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/include-media/-/include-media-1.4.10.tgz",
+      "integrity": "sha512-TymQzKF7oWHbItEcEHOCponZ90lRr1I9QbYeD+qCxXy4Z0/pSpS4Ocz2bq3FMOERlXXrY9Sawsh9GjiObVQA6A=="
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -25773,6 +25779,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "include-media": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/include-media/-/include-media-1.4.10.tgz",
+      "integrity": "sha512-TymQzKF7oWHbItEcEHOCponZ90lRr1I9QbYeD+qCxXy4Z0/pSpS4Ocz2bq3FMOERlXXrY9Sawsh9GjiObVQA6A=="
     },
     "indent-string": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fast-deep-equal": "^3.1.3",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.0.0-rc.7",
+    "include-media": "^1.4.10",
     "install": "^0.13.0",
     "jspdf": "^2.3.1",
     "just-left-pad": "^2.1.0",

--- a/src/components/notifications/Notifications.svelte
+++ b/src/components/notifications/Notifications.svelte
@@ -52,7 +52,9 @@
   }
 </script>
 
-<style>
+<style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   :global(.toasts) {
     list-style: none;
     position: fixed;
@@ -112,7 +114,7 @@
     }
   }
 
-  @media (min-width: 480px) {
+  @include media(">=480px") {
     @keyframes animate-in {
       0%,
       60%,

--- a/src/components/tools/Partials/Dashboard/index.svelte
+++ b/src/components/tools/Partials/Dashboard/index.svelte
@@ -82,7 +82,7 @@
     }
   }
 
-  @include mobile-tablet {
+  @include mq-mobile-tablet {
     .dashboard {
       .content {
         padding-right: 0;

--- a/src/components/tools/Partials/Dashboard/index.svelte
+++ b/src/components/tools/Partials/Dashboard/index.svelte
@@ -22,6 +22,8 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .dashboard {
     display: flex;
     max-width: 99rem;
@@ -61,23 +63,26 @@
   }
   // end overrides for tab content area
 
-  @media (max-width: 1000px) {
+  @include media("<=1000px") {
     .dashboard {
       flex-direction: column;
 
+      .sidebar,
       .content {
         width: 100%;
+      }
+
+      .content {
         padding-right: 1rem;
       }
 
       .sidebar {
-        width: 100%;
         padding-left: 2rem;
       }
     }
   }
 
-  @media (max-width: 672px) {
+  @include mobile-tablet {
     .dashboard {
       .content {
         padding-right: 0;

--- a/src/components/tools/Partials/Dashboard/index.svelte
+++ b/src/components/tools/Partials/Dashboard/index.svelte
@@ -63,7 +63,7 @@
   }
   // end overrides for tab content area
 
-  @include media("<=1000px") {
+  @include mq-custom-1000px {
     .dashboard {
       flex-direction: column;
 

--- a/src/partials/Banner.svelte
+++ b/src/partials/Banner.svelte
@@ -16,7 +16,9 @@
     /\//.test(str) ? `url(${str})` : str;
 </script>
 
-<style>
+<style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .banner {
     min-height: 16rem;
     color: var(--white);
@@ -28,7 +30,7 @@
     padding: var(--spacing-48) 0;
   }
 
-  @media (max-width: 672px) {
+  @include media("<=medium") {
     .banner {
       min-height: 14rem;
       background-image: var(--banner-img-mobile, var(--banner-img), none);

--- a/src/partials/Footer.svelte
+++ b/src/partials/Footer.svelte
@@ -6,6 +6,8 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   footer {
     background-image: linear-gradient(
       to top,
@@ -24,7 +26,7 @@
     align-content: center;
     align-items: center;
 
-    @media (max-width: 66rem) {
+    @include media("<=large") {
       text-align: center;
       justify-content: center;
     }
@@ -44,7 +46,7 @@
       margin: 0.5rem;
     }
 
-    @media (max-width: 66rem) {
+    @include media("<=large") {
       justify-content: space-evenly;
     }
   }

--- a/src/partials/Nav/Nav.svelte
+++ b/src/partials/Nav/Nav.svelte
@@ -91,20 +91,20 @@
         style="padding-left:0;padding-right:0;"
       >
         <Button
+          on:click="{() => (open = !open)}"
           kind="secondary"
           icon="{open ? Close32 : Menu32}"
           iconDescription="{open ? 'Close menu' : 'Open menu'}"
           tooltipPosition="left"
-          on:click="{() => (open = !open)}"
           class="menu-toggle"
           style="background-color: var(--gray-90); float:right;"
         />
 
         {#if open}
           <NavItems
+            on:click="{handleNavItemClick}"
             navItems="{navItems}"
             segment="{segment}"
-            handleClick="{handleNavItemClick}"
           />
         {/if}
       </div>

--- a/src/partials/Nav/NavItems.svelte
+++ b/src/partials/Nav/NavItems.svelte
@@ -1,12 +1,14 @@
 <script>
   export let navItems = [];
   export let segment;
-  export let handleClick = () => {};
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .bx--header__nav {
     float: right;
+    display: block;
 
     &:before {
       background: transparent;
@@ -28,7 +30,7 @@
     border-bottom: 3px solid var(--accent);
   }
 
-  @media (max-width: 66rem) {
+  @include media("<large") {
     .bx--header__nav {
       display: block;
       height: auto;
@@ -59,6 +61,7 @@
     {#each navItems as item, i}
       <li>
         <a
+          on:click
           sapper:prefetch
           href="{item.path}"
           class="bx--header__menu-item"
@@ -66,7 +69,6 @@
           aria-current="{segment === item.label.toLowerCase()
             ? 'page'
             : undefined}"
-          on:click="{handleClick}"
         >
           <span class="bx--text-truncate--end">{item.label}</span>
         </a>

--- a/src/partials/PageNav.svelte
+++ b/src/partials/PageNav.svelte
@@ -63,7 +63,7 @@
     top: 93%;
   }
 
-  @include custom-1000 {
+  @include mq-custom-1000px {
     .page-nav :global(.bx--side-nav__items) {
       flex-direction: column;
     }

--- a/src/partials/PageNav.svelte
+++ b/src/partials/PageNav.svelte
@@ -30,6 +30,8 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .page-nav {
     width: 100%;
     background: rgba(250, 251, 251, 1);
@@ -61,7 +63,7 @@
     top: 93%;
   }
 
-  @media (max-width: 1000px) {
+  @include custom-1000 {
     .page-nav :global(.bx--side-nav__items) {
       flex-direction: column;
     }

--- a/src/partials/SidebarRight.svelte
+++ b/src/partials/SidebarRight.svelte
@@ -42,7 +42,7 @@
       margin-top: 4rem;
     }
 
-    @include custom-1000 {
+    @include mq-custom-1000px {
       margin-top: 3rem;
     }
   }

--- a/src/partials/SidebarRight.svelte
+++ b/src/partials/SidebarRight.svelte
@@ -35,12 +35,14 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .sidebar-block {
     &:not(:first-of-type) {
       margin-top: 4rem;
     }
 
-    @media (max-width: 1000px) {
+    @include custom-1000 {
       margin-top: 3rem;
     }
   }

--- a/src/routes/about/index.svelte
+++ b/src/routes/about/index.svelte
@@ -60,14 +60,16 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   figure {
     margin: 0;
 
-    @media (max-width: 1052px) {
+    @include media("<=large") {
       margin: 2rem;
     }
 
-    @media (max-width: 672px) {
+    @include media("<=medium") {
       margin: 2rem 0;
     }
   }
@@ -79,7 +81,7 @@
   }
 
   img.report {
-    @media (max-width: 1052px) {
+    @include media("<=large") {
       max-width: 60%;
       margin: 0;
     }
@@ -122,7 +124,7 @@
       height: 100%;
     }
 
-    @media (max-width: 1056px) {
+    @include media("<=large") {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -200,7 +202,7 @@
       font-size: 0.875rem;
     }
 
-    @media (max-width: 672px) {
+    @include media("<=medium") {
       grid-template-columns: repeat(auto-fill, minmax(calc(50% - 1rem), 1fr));
     }
   }

--- a/src/routes/help/index.svelte
+++ b/src/routes/help/index.svelte
@@ -41,7 +41,7 @@
       text-align: right;
     }
 
-    @include custom-1000 {
+    @include mq-custom-1000px {
       > div:nth-child(2) {
         text-align: left;
       }

--- a/src/routes/help/index.svelte
+++ b/src/routes/help/index.svelte
@@ -31,6 +31,8 @@
 </script>
 
 <style lang="scss">
+  @import "scss/site/mixins/media-queries";
+
   .help-footer {
     .h4 {
       margin-bottom: 0.5rem;
@@ -39,7 +41,7 @@
       text-align: right;
     }
 
-    @media (max-width: 1000px) {
+    @include custom-1000 {
       > div:nth-child(2) {
         text-align: left;
       }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,4 +1,3 @@
-@import "carbon-components/scss/globals/scss/spacing";
 @import "./src/scss/site/variables";
 @import "carbon-components/scss/globals/scss/vendor/@carbon/themes/scss/themes.scss";
 

--- a/src/scss/site/_carbon-overrides.scss
+++ b/src/scss/site/_carbon-overrides.scss
@@ -1,3 +1,5 @@
+@import "./mixins/media-queries";
+
 .sidebar {
   .bx--side-nav__menu {
     a.bx--side-nav__link {
@@ -111,7 +113,7 @@
 }
 
 /* Responsive Structured List */
-@media (max-width: 700px) {
+@include media("<=medium") {
   .bx--structured-list-row {
     display: flex;
     flex-direction: column;

--- a/src/scss/site/_grids.scss
+++ b/src/scss/site/_grids.scss
@@ -1,3 +1,5 @@
+@import "./mixins/media-queries";
+
 .page-grid {
   display: grid;
   grid-gap: 10px;
@@ -35,7 +37,7 @@
     grid-column: 2 / span 3;
     margin-bottom: var(--spacing-13, 10rem);
 
-    @media (max-width: 1000px) {
+    @include custom-1000 {
       grid-column: 1;
     }
   }
@@ -50,7 +52,7 @@
     "sidebar-left content sidebar-right"
     "sidebar-left footer sidebar-right";
 
-  @media (max-width: 1000px) {
+  @include custom-1000 {
     grid-template-columns: 100%;
     grid-template-rows: auto;
     grid-template-areas:
@@ -93,7 +95,7 @@
     "content sidebar-right"
     "footer sidebar-right";
 
-  @media (max-width: 1000px) {
+  @include custom-1000 {
     grid-template-columns: 100%;
     grid-template-areas:
       "sidebar-right"
@@ -109,7 +111,7 @@
     "content sidebar-right"
     "footer sidebar-right";
 
-  @media (max-width: 1000px) {
+  @include custom-1000 {
     grid-template-columns: 100%;
     grid-template-rows: auto;
     grid-template-areas:
@@ -133,7 +135,7 @@
       position: relative;
       width: calc(30% - 1rem);
 
-      @media (max-width: 1000px) {
+      @include custom-1000 {
         width: calc(45% - 1rem);
       }
 

--- a/src/scss/site/_grids.scss
+++ b/src/scss/site/_grids.scss
@@ -37,7 +37,7 @@
     grid-column: 2 / span 3;
     margin-bottom: var(--spacing-13, 10rem);
 
-    @include custom-1000 {
+    @include mq-custom-1000px {
       grid-column: 1;
     }
   }
@@ -52,7 +52,7 @@
     "sidebar-left content sidebar-right"
     "sidebar-left footer sidebar-right";
 
-  @include custom-1000 {
+  @include mq-custom-1000px {
     grid-template-columns: 100%;
     grid-template-rows: auto;
     grid-template-areas:
@@ -95,7 +95,7 @@
     "content sidebar-right"
     "footer sidebar-right";
 
-  @include custom-1000 {
+  @include mq-custom-1000px {
     grid-template-columns: 100%;
     grid-template-areas:
       "sidebar-right"
@@ -111,7 +111,7 @@
     "content sidebar-right"
     "footer sidebar-right";
 
-  @include custom-1000 {
+  @include mq-custom-1000px {
     grid-template-columns: 100%;
     grid-template-rows: auto;
     grid-template-areas:
@@ -135,7 +135,7 @@
       position: relative;
       width: calc(30% - 1rem);
 
-      @include custom-1000 {
+      @include mq-custom-1000px {
         width: calc(45% - 1rem);
       }
 

--- a/src/scss/site/_icons.scss
+++ b/src/scss/site/_icons.scss
@@ -2,7 +2,7 @@
   width: 60px;
   display: inline-block;
 
-  @include custom-1000 {
+  @include mq-custom-1000px {
     width: 45px;
   }
 }

--- a/src/scss/site/_icons.scss
+++ b/src/scss/site/_icons.scss
@@ -2,7 +2,7 @@
   width: 60px;
   display: inline-block;
 
-  @media (max-width: 1000px) {
+  @include custom-1000 {
     width: 45px;
   }
 }

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -264,7 +264,8 @@ $spacing-160: $layout-2xl;
 $p-default-max-width: 75ch;
 $p-lead-default-max-width: 55ch;
 
-// breakpoints correspond to those for Carbon Grid
+// Breakpoints correspond to those for Carbon Design Grid.
+// Use these when aligning layout changes with the .bx--grid
 // see: https://www.carbondesignsystem.com/guidelines/2x-grid/overview/
 $breakpoint-small: 20rem; // 320px
 $breakpoint-medium: 42rem; // 672px

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -1,3 +1,5 @@
+@import "carbon-components/scss/globals/scss/spacing";
+
 // Colors
 $white: #ffffff;
 $black: #090f20;
@@ -34,6 +36,18 @@ $teal-100: #001818;
 $rs-green: #5dfa25;
 $rs-blue: #25c7fa;
 $rs-teal: #88dcc4;
+
+// gcms
+$gcm-ACCESS1-0: rgba(31, 119, 180, 1);
+$gcm-CanESM2: rgba(188, 189, 34, 1);
+$gcm-CCSM4: rgba(44, 160, 44, 1);
+$gcm-CESM1-BGC: rgba(140, 86, 75, 1);
+$gcm-CMCC-CMS: rgba(227, 119, 194, 1);
+$gcm-CNRM-CM5: rgba(23, 190, 207, 1);
+$gcm-GFDL-CM3: rgba(255, 127, 14, 1);
+$gcm-HadGEM2-CC: rgba(69, 68, 68, 1);
+$gcm-HadGEM2-ES: rgba(214, 39, 40, 1);
+$gcm-MIROC5: rgba(148, 103, 189, 1);
 
 $card-gradient-01: linear-gradient(
   180deg,
@@ -250,17 +264,21 @@ $spacing-160: $layout-2xl;
 $p-default-max-width: 75ch;
 $p-lead-default-max-width: 55ch;
 
-// gcms
-$gcm-ACCESS1-0: rgba(31, 119, 180, 1);
-$gcm-CanESM2: rgba(188, 189, 34, 1);
-$gcm-CCSM4: rgba(44, 160, 44, 1);
-$gcm-CESM1-BGC: rgba(140, 86, 75, 1);
-$gcm-CMCC-CMS: rgba(227, 119, 194, 1);
-$gcm-CNRM-CM5: rgba(23, 190, 207, 1);
-$gcm-GFDL-CM3: rgba(255, 127, 14, 1);
-$gcm-HadGEM2-CC: rgba(69, 68, 68, 1);
-$gcm-HadGEM2-ES: rgba(214, 39, 40, 1);
-$gcm-MIROC5: rgba(148, 103, 189, 1);
+// breakpoints correspond to those for Carbon Grid
+// see: https://www.carbondesignsystem.com/guidelines/2x-grid/overview/
+$breakpoint-small: 20rem; // 320px
+$breakpoint-medium: 42rem; // 672px
+$breakpoint-large: 66rem; // 1056px
+$breakpoint-extra-large: 82rem; //  1312px;
+$breakpoint-max: 99rem; // 1584px;
+
+$breakpoints: (
+  small: $breakpoint-small,
+  medium: $breakpoint-medium,
+  large: $breakpoint-large,
+  extra-large: $breakpoint-extra-large,
+  max: $breakpoint-max,
+);
 
 // Sass variables as CSS Custom Properties to fix variables in .svelte components
 :root {

--- a/src/scss/site/_variables.scss
+++ b/src/scss/site/_variables.scss
@@ -273,12 +273,17 @@ $breakpoint-large: 66rem; // 1056px
 $breakpoint-extra-large: 82rem; //  1312px;
 $breakpoint-max: 99rem; // 1584px;
 
+// custom legacy breakpoints that do not conform to the carbon grid but are used
+// frequently throughout the app
+$breakpoint-custom-1000: 62.5rem; // 1000px;
+
 $breakpoints: (
   small: $breakpoint-small,
   medium: $breakpoint-medium,
   large: $breakpoint-large,
   extra-large: $breakpoint-extra-large,
   max: $breakpoint-max,
+  custom-1000: $breakpoint-custom-1000,
 );
 
 // Sass variables as CSS Custom Properties to fix variables in .svelte components

--- a/src/scss/site/mixins/_media-queries.scss
+++ b/src/scss/site/mixins/_media-queries.scss
@@ -43,7 +43,7 @@
 }
 
 // custom media query for 1000px
-@mixin custom-1000 {
+@mixin mq-custom-1000px {
   @include media("<=custom-1000") {
     @content;
   }

--- a/src/scss/site/mixins/_media-queries.scss
+++ b/src/scss/site/mixins/_media-queries.scss
@@ -1,0 +1,38 @@
+@import "../variables";
+@import "include-media/dist/include-media";
+
+// MEDIA QUERIES
+// These use the `include-media` Sass library
+// https://eduardoboucas.github.io/include-media/
+// Breakpoint variables are configured to match Carbon Design's grid breakpoints.
+// Note that custom `@include media(a, b)` may also be created, e.g.
+// `@include media(">=small", "<800px") { ... }`
+// Note that these were added 2022-04-27 and are not used widely yet across the app
+
+// use when applying media queries for desktop width viewports
+@mixin desktop {
+  @include media(">large") {
+    @content;
+  }
+}
+
+// use when applying media queries for both tablet & mobile width viewports
+@mixin mobile-tablet {
+  @include media("<=large") {
+    @content;
+  }
+}
+
+// use when applying media queries for tablet width viewports
+@mixin tablet {
+  @include media(">small", "<=large") {
+    @content;
+  }
+}
+
+// use when applying media queries for mobile device width viewports
+@mixin mobile {
+  @include media("<=small") {
+    @content;
+  }
+}

--- a/src/scss/site/mixins/_media-queries.scss
+++ b/src/scss/site/mixins/_media-queries.scss
@@ -15,28 +15,28 @@
 // ```
 
 // use when applying media queries for desktop width viewports
-@mixin desktop {
+@mixin mq-desktop {
   @include media(">large") {
     @content;
   }
 }
 
 // use when applying media queries for both tablet & mobile width viewports
-@mixin mobile-tablet {
+@mixin mq-mobile-tablet {
   @include media("<=large") {
     @content;
   }
 }
 
 // use when applying media queries for tablet width viewports
-@mixin tablet {
+@mixin mq-tablet {
   @include media(">small", "<=large") {
     @content;
   }
 }
 
 // use when applying media queries for mobile device width viewports
-@mixin mobile {
+@mixin mq-mobile {
   @include media("<=small") {
     @content;
   }

--- a/src/scss/site/mixins/_media-queries.scss
+++ b/src/scss/site/mixins/_media-queries.scss
@@ -36,3 +36,10 @@
     @content;
   }
 }
+
+// custom media query for 1000px
+@mixin custom-1000 {
+  @include media("<=custom-1000") {
+    @content;
+  }
+}

--- a/src/scss/site/mixins/_media-queries.scss
+++ b/src/scss/site/mixins/_media-queries.scss
@@ -2,12 +2,17 @@
 @import "include-media/dist/include-media";
 
 // MEDIA QUERIES
-// These use the `include-media` Sass library
-// https://eduardoboucas.github.io/include-media/
+// These use the `include-media` Sass library. The intention is to use these mixins
+// when writing a media query block to help ensure consistency and semantics.
+// For more on `include-media` see:
+// * https://eduardoboucas.github.io/include-media/
+// * https://css-tricks.com/approaches-media-queries-sass/#aa-my-eduardo-boucass-technique
 // Breakpoint variables are configured to match Carbon Design's grid breakpoints.
-// Note that custom `@include media(a, b)` may also be created, e.g.
-// `@include media(">=small", "<800px") { ... }`
-// Note that these were added 2022-04-27 and are not used widely yet across the app
+// Custom breakpoints may also be used: `@include media(a, b)`
+// For example:
+// ```
+// @include media(">=small", "<800px") { ... }
+// ```
 
 // use when applying media queries for desktop width viewports
 @mixin desktop {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,9 +18,9 @@ const sourceMap = dev ? "inline-cheap-module-source-map" : "source-map";
 const alias = {
   "~": path.resolve(__dirname, "src/"),
   content: path.resolve(__dirname, "content"),
+  scss: path.resolve(__dirname, "src/scss"),
   static: path.resolve(__dirname, "static"),
   svelte: path.resolve("node_modules", "svelte"),
-  scss: path.resolve(__dirname, "src/scss"),
 };
 const extensions = [".mjs", ".js", ".json", ".svelte", ".html"];
 const mainFields = ["svelte", "module", "browser", "main"];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const alias = {
   content: path.resolve(__dirname, "content"),
   static: path.resolve(__dirname, "static"),
   svelte: path.resolve("node_modules", "svelte"),
+  scss: path.resolve(__dirname, "src/scss"),
 };
 const extensions = [".mjs", ".js", ".json", ".svelte", ".html"];
 const mainFields = ["svelte", "module", "browser", "main"];


### PR DESCRIPTION
- [x] adds CSS media query Sass mixins via the [include-media](https://www.npmjs.com/package/include-media) scss library.
- [x] replaces existing media queries with their corresponding mixin to encourage consistency