### PR TITLE
bug fix: location store

### DIFF
--- a/src/routes/tools/_common/stores.js
+++ b/src/routes/tools/_common/stores.js
@@ -91,7 +91,6 @@ export const locationStore = (() => {
     subscribe,
     updateLocation: (location, isUpload = false) =>
       update((store) => {
-        if (!location) return;
         store.location = location;
         store.isUpload = isUpload;
         return store;


### PR DESCRIPTION
Removes an early return when updating the `location` property of the `locationStore` (Svelte store) to prevent the store from breaking.

This doesn't fix the issue I [recently mentioned in Trello](https://trello.com/c/8JmopK9Q/198-bug-bookmarked-location-may-fail-to-load-desired-location-for-any-tool), but it is related and may cause problems elsewhere.