### PR TITLE
bug fix: share link / bookmark location

### DIFF
--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -66,6 +66,7 @@
     )}`;
   }
 
+  // FIXME: this creates invalid geometries for some boundaries, e.g. Tehama County
   function createOverlay(geojson, tolerance = 0.005) {
     const overlay = encodeURIComponent(JSON.stringify(geojson));
     if (overlay.length < 7500) {

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -108,10 +108,14 @@
     };
     const bounds = "auto";
     const params = { access_token: accessToken, padding };
-    // The Mapbox Static Images API only accepts requests that are 8,192 or fewer characters long.
-    // Reduce coordinate precision
-    const truncatedGeojson = truncate(geojson, { precision: 4 });
-    // Simplify geometry
+    // The Mapbox Static Images API only accepts requests that are 8,192 or
+    // fewer characters long. So we...
+    // 1. reduce coordinate precision
+    const truncatedGeojson = truncate(geojson, {
+      precision: 4,
+      coordinates: 2,
+    });
+    // 2. simplify the geometry
     const overlay = createOverlay(truncatedGeojson);
     createSrcUrl({ overlay, bounds, params });
   }

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -66,7 +66,7 @@
     )}`;
   }
 
-  // FIXME: this creates invalid geometries for some boundaries, e.g. Tehama County
+  // BUG: this creates invalid geometries for some boundaries, e.g. Tehama County
   function createOverlay(geojson, tolerance = 0.005) {
     const overlay = encodeURIComponent(JSON.stringify(geojson));
     if (overlay.length < 7500) {

--- a/src/components/tools/Partials/ShareLink.svelte
+++ b/src/components/tools/Partials/ShareLink.svelte
@@ -1,19 +1,33 @@
 <script>
-  import { Modal, CodeSnippet } from "carbon-components-svelte";
+  import {
+    Modal,
+    CodeSnippet,
+    InlineNotification,
+  } from "carbon-components-svelte";
   import copy from "clipboard-copy";
 
   export let open = false;
   export let state;
+  export let errorMsg = "";
 
   $: pathname = `${window.location.origin}${window.location.pathname}`;
   $: bookmark = `${pathname}?${state}`;
 </script>
 
 <Modal id="share" passiveModal bind:open modalHeading="Share Link">
-  <CodeSnippet
-    type="multi"
-    wrapText
-    code="{bookmark}"
-    on:click="{() => copy(bookmark)}"
-  />
+  {#if errorMsg}
+    <InlineNotification
+      lowContrast="{true}"
+      kind="warning"
+      title="Warning:"
+      subtitle="{errorMsg}"
+    />
+  {:else}
+    <CodeSnippet
+      type="multi"
+      wrapText
+      code="{bookmark}"
+      on:click="{() => copy(bookmark)}"
+    />
+  {/if}
 </Modal>

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -11,7 +11,7 @@
   } from "./../../../helpers/utilities";
   import { formatFeature } from "./../../../helpers/geocode";
 
-  let fileUploader;
+  const dispatch = createEventDispatcher();
   const fileUploadProps = {
     labelTitle: "",
     labelDescription:
@@ -23,6 +23,8 @@
     errorSubject: "",
     errorBody: "",
   };
+
+  let fileUploader;
 
   $: if (fileUploader) {
     fileUploader.clearFiles();
@@ -36,8 +38,6 @@
     fileUploadProps.invalid = false;
     dispatch("clear");
   }
-
-  const dispatch = createEventDispatcher();
 
   async function processUpload(file) {
     console.log("....uploadng");

--- a/src/helpers/__mocks__/geocode.js
+++ b/src/helpers/__mocks__/geocode.js
@@ -3,7 +3,12 @@
 // see: https://jestjs.io/docs/manual-mocks
 
 export function getTitle(feature = {}, boundaryType = "", placeName = "") {
-  return "New place name";
+  if (boundaryType === "locagrid") {
+    return feature.properties && feature.properties.name
+      ? `LOCA Grid Cell ${feature.properties.name}`
+      : "LOCA Grid Cell";
+  }
+  return placeName || "New place name";
 }
 
 export function formatFeature(

--- a/src/helpers/__mocks__/geocode.js
+++ b/src/helpers/__mocks__/geocode.js
@@ -1,0 +1,76 @@
+// This file contains manual mocks for the ../geocode.js module.
+// These are intended to be used for unit tests with Jest.
+// see: https://jestjs.io/docs/manual-mocks
+
+export function formatFeature(
+  feature = {},
+  boundaryType = "locagrid",
+  placeName = ""
+) {
+  return {
+    title: getTitle(feature, boundaryType, placeName),
+    center: [0, 0],
+    bbox: [0, 0, 0, 0],
+    id: feature.id || 1234,
+    geometry: {},
+    properties: {},
+  };
+}
+
+export function getFeature(feature = {}, boundaryId = "locagrid") {
+  return new Promise((resolve, reject) => {
+    if (!feature || !boundaryId)
+      reject({
+        error: `Must be called with args for feature and boundaryId`,
+      });
+
+    resolve(formatFeature(feature, boundaryId));
+  });
+}
+
+export function getFeatureById(
+  boundaryType = "locagrid",
+  featureId = 0,
+  params = { srs: 4326 }
+) {
+  return new Promise((resolve, reject) => {
+    if (!boundaryType || !featureId)
+      reject({
+        error: `Must be called with args for boundaryType and featureId`,
+      });
+
+    resolve(formatFeature({ id: featureId }, boundaryType));
+  });
+}
+
+export function reverseGeocode(coords = [0, 0]) {
+  return new Promise((resolve, reject) => {
+    if (!coords) {
+      reject({
+        error: "Must be called with arg for coords",
+      });
+    }
+    resolve({
+      type: "FeatureCollection",
+      query: coords.slice(),
+      features: [
+        {
+          type: "Feature",
+          id: "address.12345",
+          place_name: "Somewhere, California",
+          properties: {
+            accuracy: "street",
+          },
+          geometry: {
+            type: "Point",
+            coordinates: coords.slice(),
+          },
+        },
+      ],
+    });
+  });
+}
+
+export function getTitle(feature = {}, boundaryType = "", placeName = "") {
+  return "New place name";
+}

--- a/src/helpers/__mocks__/geocode.js
+++ b/src/helpers/__mocks__/geocode.js
@@ -2,6 +2,10 @@
 // These are intended to be used for unit tests with Jest.
 // see: https://jestjs.io/docs/manual-mocks
 
+export function getTitle(feature = {}, boundaryType = "", placeName = "") {
+  return "New place name";
+}
+
 export function formatFeature(
   feature = {},
   boundaryType = "locagrid",
@@ -69,8 +73,4 @@ export function reverseGeocode(coords = [0, 0]) {
       ],
     });
   });
-}
-
-export function getTitle(feature = {}, boundaryType = "", placeName = "") {
-  return "New place name";
 }

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -137,10 +137,14 @@ export const getFeature = async (feature, boundaryId) => {
   return location;
 };
 
-export const getFeatureById = async (boundaryType, featureId) => {
+export const getFeatureById = async (
+  boundaryType,
+  featureId,
+  params = { srs: 4326 }
+) => {
   let location = null;
   const url = `${apiEndpoint}/${boundaryType}/${featureId}/`;
-  const [response, error] = await handleXHR(fetchData(url, {}));
+  const [response, error] = await handleXHR(fetchData(url, params));
   if (error) {
     throw new Error(error.message);
   }

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -147,7 +147,7 @@ export const getFeature = async (feature, boundaryId) => {
  * @param {number} featureId - numeric value of feature id
  * @param {object} params - additional parameters
  * @param {number} params.srs - desired reference system to return coordinates in
- * @returns {object} GeoJSON feature on success, Error on failure.
+ * @returns {object} formatted location data on success, Error on failure.
  */
 export const getFeatureById = async (
   boundaryType,

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -137,6 +137,14 @@ export const getFeature = async (feature, boundaryId) => {
   return location;
 };
 
+/**
+ * Queries a boundary feature from the Cal-Adapt API using its unique feature id
+ * @param {string} boundaryType - locagrid, counties, censustracts, etc.
+ * @param {number} featureId - numeric value of feature id
+ * @param {object} params - additional parameters
+ * @param {number} params.srs - desired reference system to return coordinates in
+ * @returns {object} GeoJSON feature on success, Error on failure.
+ */
 export const getFeatureById = async (
   boundaryType,
   featureId,

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -71,7 +71,9 @@ export const getBoundaryPolygon = async (coords, boundaryId) => {
 export const getTitle = (feature, layerId, placeName) => {
   switch (layerId) {
     case "locagrid":
-      return placeName.replace(", United States", "");
+      return feature.properties && feature.properties.name
+        ? `LOCA Grid Cell ${feature.properties.name}`
+        : "LOCA Grid Cell";
     case "counties":
       return `${feature.properties.name} County, ${feature.properties.state_name}`;
     case "censustracts":

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -68,15 +68,6 @@ export const getBoundaryPolygon = async (coords, boundaryId) => {
   return response;
 };
 
-export const getFeatureById = async (id, layerId) => {
-  const url = `${apiEndpoint}/${layerId}/${id}`;
-  const [response, error] = await handleXHR(fetchData(url, {}));
-  if (error) {
-    throw new Error(error.message);
-  }
-  return response;
-};
-
 export const getTitle = (feature, layerId, placeName) => {
   switch (layerId) {
     case "locagrid":
@@ -142,6 +133,19 @@ export const getFeature = async (feature, boundaryId) => {
         feature.place_name
       );
     }
+  }
+  return location;
+};
+
+export const getFeatureById = async (boundaryType, featureId) => {
+  let location = null;
+  const url = `${apiEndpoint}/${boundaryType}/${featureId}/`;
+  const [response, error] = await handleXHR(fetchData(url, {}));
+  if (error) {
+    throw new Error(error.message);
+  }
+  if (response) {
+    location = formatFeature(response, boundaryType);
   }
   return location;
 };

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -41,12 +41,13 @@ export function deserialize(paramsStr) {
  * @param {object} params
  * @return {string}
  */
-export function serialize(params) {
-  const parts = [];
-  Object.keys(params).forEach((key) => {
-    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`);
-  });
-  return `${parts.join("&")}`;
+export function serialize(params = {}) {
+  return Object.entries(params)
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+    )
+    .join("&");
 }
 
 /**

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -6,6 +6,7 @@ import {
   MONTHS_LIST,
   PRIORITY_10_MODELS,
   DEFAULT_LOCATION,
+  DEFAULT_BOUNDARIES,
   DEFAULT_LOCAGRIDCELL_TITLE,
 } from "./constants";
 import { isLeapYear, isValidNumber, serialize } from "~/helpers/utilities";
@@ -17,6 +18,10 @@ import {
 } from "~/helpers/geocode";
 
 export { serialize };
+
+export const PERMITTED_BOUNDARY_TYPES = new Set(
+  DEFAULT_BOUNDARIES.map((d) => d.id)
+);
 
 /**
  * Groups data for 2 or more timeseries by year, outputs a single timeseries with
@@ -314,13 +319,17 @@ export const getInitialConfig = (
 export async function setInitialLocation(lng, lat, boundary, featureId) {
   let loc = DEFAULT_LOCATION;
 
-  if (isValidNumber(featureId)) {
+  if (isValidNumber(featureId) && PERMITTED_BOUNDARY_TYPES.has(boundary)) {
     try {
       loc = await getFeatureById(boundary, featureId);
     } catch (error) {
       console.warn(error);
     }
-  } else if (isValidNumber(lng) && isValidNumber(lat)) {
+  } else if (
+    isValidNumber(lng) &&
+    isValidNumber(lat) &&
+    PERMITTED_BOUNDARY_TYPES.has(boundary)
+  ) {
     // Prior to PR#235 feature data was retrieved this way, but it is error prone.
     // For more info, see: https://trello.com/c/8JmopK9Q
     // NOTE: this code still exists in case a legacy bookmarked URL that only

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -317,11 +317,11 @@ export const getInitialConfig = (
  * @return {object} - GeoJSON feature or feature collection on success
  */
 export async function setInitialLocation(lng, lat, boundary, featureId) {
-  let loc = DEFAULT_LOCATION;
+  let location = DEFAULT_LOCATION;
 
   if (isValidNumber(featureId) && PERMITTED_BOUNDARY_TYPES.has(boundary)) {
     try {
-      loc = await getFeatureById(boundary, featureId);
+      location = await getFeatureById(boundary, featureId);
     } catch (error) {
       console.warn(error);
     }
@@ -330,36 +330,20 @@ export async function setInitialLocation(lng, lat, boundary, featureId) {
     isValidNumber(lat) &&
     PERMITTED_BOUNDARY_TYPES.has(boundary)
   ) {
-    // Prior to PR#235 feature data was retrieved this way, but it is error prone.
-    // For more info, see: https://trello.com/c/8JmopK9Q
-    // NOTE: this code still exists in case a legacy bookmarked URL that only
-    // has the lng,lat coords and not the featureId.
+    // NOTE: prior to PR #235 feature data was retrieved this way, but it is
+    // error prone. For more info, see: https://trello.com/c/8JmopK9Q
+    // This code still exists in case a legacy bookmarked URL only
+    // contains the lng,lat center coords and not the featureId.
     try {
-      loc = await getFeature({ center: [lng, lat] }, boundary);
+      location = await getFeature({ center: [lng, lat] }, boundary);
     } catch (error) {
       console.warn(error);
     }
   } else {
-    return loc;
+    return location;
   }
 
-  // FIXME: locagrid should use its own title which consists of the lng, lat of
-  // its centroid coords.
-  if (boundary === "locagrid") {
-    let placeName = DEFAULT_LOCAGRIDCELL_TITLE;
-    try {
-      const result = await reverseGeocode(`${lng}, ${lat}`);
-      if (result && result.features && result.features.length) {
-        placeName = result.features[0].place_name;
-      }
-    } catch (error) {
-      console.warn(error);
-    } finally {
-      loc.title = getTitle(loc, boundary, placeName);
-    }
-  }
-
-  return loc;
+  return location;
 }
 
 /**

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -9,7 +9,12 @@ import {
   DEFAULT_LOCAGRIDCELL_TITLE,
 } from "./constants";
 import { isLeapYear, serialize } from "~/helpers/utilities";
-import { getFeature, reverseGeocode, getTitle } from "~/helpers/geocode";
+import {
+  getFeature,
+  reverseGeocode,
+  getTitle,
+  getFeatureById,
+} from "~/helpers/geocode";
 
 export { serialize };
 
@@ -301,19 +306,32 @@ export const getInitialConfig = (
  * Create initial location
  * @param {float} lng
  * @param {float} lat
- * @param {string} boundary - boundary id
+ * @param {string} boundary - boundary type, e.g. "locagrid", "counties", etc.
+ * @param {number} featureId - unique id of location feature
  * @return {object}
  */
 // Helper function to create an object with initial location for a Cal-Adapt tool
-export async function setInitialLocation(lng, lat, boundary) {
+export async function setInitialLocation(lng, lat, boundary, featureId) {
   let loc = DEFAULT_LOCATION;
 
-  try {
-    loc = await getFeature({ center: [lng, lat] }, boundary);
-  } catch (error) {
-    console.warn(error);
+  if (featureId) {
+    try {
+      loc = await getFeatureById(boundary, featureId);
+    } catch (error) {
+      console.warn(error);
+    }
+  } else if (lng && lat) {
+    try {
+      loc = await getFeature({ center: [lng, lat] }, boundary);
+    } catch (error) {
+      console.warn(error);
+    }
+  } else {
+    return loc;
   }
 
+  // FIXME: locagrid should use its own title which consists of the lng,lat of
+  // its centroid coords.
   if (boundary === "locagrid") {
     let placeName = DEFAULT_LOCAGRIDCELL_TITLE;
     try {

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -307,11 +307,11 @@ export const getInitialConfig = (
  * Typically used to create an object with initial location for a Cal-Adapt tool.
  * @param {float} lng - feature's centroid longitude coordinate
  * @param {float} lat - feature's centroid latitude coordinate
- * @param {string} boundary - boundary type, e.g. "locagrid", "counties", etc.
+ * @param {string} boundaryType - Cal-Adapt API boundary type, e.g. "locagrid", "counties", etc.
  * @param {number} featureId - unique id of location feature
  * @return {object} results
  * @return {object} results.location - formatted location data
- * @return {string} results.boundaryType - the boundary type (e.g. "locagrid")
+ * @return {string} results.boundaryType - Cal-Adapt API boundary type
  */
 export async function setInitialLocation(lng, lat, boundaryType, featureId) {
   let location = DEFAULT_LOCATION;

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -8,20 +8,10 @@ import {
   DEFAULT_LOCATION,
   DEFAULT_LOCAGRIDCELL_TITLE,
 } from "./constants";
-import { isLeapYear } from "~/helpers/utilities";
+import { isLeapYear, serialize } from "~/helpers/utilities";
 import { getFeature, reverseGeocode, getTitle } from "~/helpers/geocode";
 
-/**
- * Creates a string of URL query params for a share / bookmark link
- * Typically this is passed to the ShareLink component's "state" prop.
- * @param {object} values
- * @returns {string}
- */
-export function makeBookmark(values = {}) {
-  return Object.entries(values)
-    .map(([key, value]) => `${key}=${value}`)
-    .join("&");
-}
+export { serialize };
 
 /**
  * Groups data for 2 or more timeseries by year, outputs a single timeseries with

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -303,14 +303,14 @@ export const getInitialConfig = (
 };
 
 /**
- * Create initial location
- * @param {float} lng
- * @param {float} lat
+ * setInitialLocation: Queries the Cal-Adapt API for boundary type feature(s).
+ * Typically used to create an object with initial location for a Cal-Adapt tool.
+ * @param {float} lng - feature's centroid longitude coordinate
+ * @param {float} lat - feature's centroid latitude coordinate
  * @param {string} boundary - boundary type, e.g. "locagrid", "counties", etc.
  * @param {number} featureId - unique id of location feature
- * @return {object}
+ * @return {object} - GeoJSON feature or feature collection on success
  */
-// Helper function to create an object with initial location for a Cal-Adapt tool
 export async function setInitialLocation(lng, lat, boundary, featureId) {
   let loc = DEFAULT_LOCATION;
 
@@ -321,6 +321,10 @@ export async function setInitialLocation(lng, lat, boundary, featureId) {
       console.warn(error);
     }
   } else if (lng && lat) {
+    // Prior to PR#235 feature data was retrieved this way, but it is error prone.
+    // For more info, see: https://trello.com/c/8JmopK9Q
+    // NOTE: this code still exists in case a legacy bookmarked URL that only
+    // has the lng,lat coords and not the featureId.
     try {
       loc = await getFeature({ center: [lng, lat] }, boundary);
     } catch (error) {
@@ -330,7 +334,7 @@ export async function setInitialLocation(lng, lat, boundary, featureId) {
     return loc;
   }
 
-  // FIXME: locagrid should use its own title which consists of the lng,lat of
+  // FIXME: locagrid should use its own title which consists of the lng, lat of
   // its centroid coords.
   if (boundary === "locagrid") {
     let placeName = DEFAULT_LOCAGRIDCELL_TITLE;

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -8,7 +8,7 @@ import {
   DEFAULT_LOCATION,
   DEFAULT_LOCAGRIDCELL_TITLE,
 } from "./constants";
-import { isLeapYear, serialize } from "~/helpers/utilities";
+import { isLeapYear, isValidNumber, serialize } from "~/helpers/utilities";
 import {
   getFeature,
   reverseGeocode,
@@ -314,13 +314,13 @@ export const getInitialConfig = (
 export async function setInitialLocation(lng, lat, boundary, featureId) {
   let loc = DEFAULT_LOCATION;
 
-  if (featureId) {
+  if (isValidNumber(featureId)) {
     try {
       loc = await getFeatureById(boundary, featureId);
     } catch (error) {
       console.warn(error);
     }
-  } else if (lng && lat) {
+  } else if (isValidNumber(lng) && isValidNumber(lat)) {
     // Prior to PR#235 feature data was retrieved this way, but it is error prone.
     // For more info, see: https://trello.com/c/8JmopK9Q
     // NOTE: this code still exists in case a legacy bookmarked URL that only

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -309,7 +309,9 @@ export const getInitialConfig = (
  * @param {float} lat - feature's centroid latitude coordinate
  * @param {string} boundary - boundary type, e.g. "locagrid", "counties", etc.
  * @param {number} featureId - unique id of location feature
- * @return {object} - GeoJSON feature or feature collection on success
+ * @return {object} results
+ * @return {object} results.location - formatted location data
+ * @return {string} results.boundaryType - the boundary type (e.g. "locagrid")
  */
 export async function setInitialLocation(lng, lat, boundaryType, featureId) {
   let location = DEFAULT_LOCATION;
@@ -341,10 +343,16 @@ export async function setInitialLocation(lng, lat, boundaryType, featureId) {
       handleException();
     }
   } else {
-    return location;
+    return { location, boundaryType: "locagrid" };
   }
 
-  return location;
+  if (location === DEFAULT_LOCATION) {
+    // Override the boundaryType to make sure it's not something other than "locagrid"
+    // in the case that a feature look up failed above.
+    boundaryType = "locagrid";
+  }
+
+  return { location, boundaryType };
 }
 
 /**

--- a/src/routes/tools/_common/helpers.spec.js
+++ b/src/routes/tools/_common/helpers.spec.js
@@ -4,19 +4,26 @@ import { setInitialLocation } from "./helpers";
 import { DEFAULT_LOCATION } from "./constants";
 
 describe("tools/_common/helpers", () => {
-  test("setInitialLocation default location", () => {
-    return expect(setInitialLocation()).resolves.toEqual(DEFAULT_LOCATION);
+  test("setInitialLocation returns default location", () => {
+    const expected = {
+      location: DEFAULT_LOCATION,
+      boundaryType: "locagrid",
+    };
+    return expect(setInitialLocation()).resolves.toEqual(expected);
   });
 
   test("setInitialLocation using lng lat", () => {
     const [lng, lat] = [-122.09, 37.78];
     const expected = {
-      bbox: [0, 0, 0, 0],
-      center: [0, 0],
-      geometry: {},
-      properties: {},
-      id: 1234,
-      title: "LOCA Grid Cell",
+      location: {
+        bbox: [0, 0, 0, 0],
+        center: [0, 0],
+        geometry: {},
+        properties: {},
+        id: 1234,
+        title: "LOCA Grid Cell",
+      },
+      boundaryType: "locagrid",
     };
     return expect(setInitialLocation(lng, lat, "locagrid")).resolves.toEqual(
       expected
@@ -26,12 +33,15 @@ describe("tools/_common/helpers", () => {
   test("setInitialLocation using featureId and boundary", () => {
     const featureId = 1;
     const expected = {
-      bbox: [0, 0, 0, 0],
-      center: [0, 0],
-      geometry: {},
-      properties: {},
-      id: featureId,
-      title: "New place name",
+      location: {
+        bbox: [0, 0, 0, 0],
+        center: [0, 0],
+        geometry: {},
+        properties: {},
+        id: featureId,
+        title: "New place name",
+      },
+      boundaryType: "counties",
     };
     return expect(
       setInitialLocation(null, null, "counties", 1)

--- a/src/routes/tools/_common/helpers.spec.js
+++ b/src/routes/tools/_common/helpers.spec.js
@@ -1,0 +1,40 @@
+jest.mock("../../../helpers/geocode");
+
+import { setInitialLocation } from "./helpers";
+import { DEFAULT_LOCATION } from "./constants";
+
+describe("tools/_common/helpers", () => {
+  test("setInitialLocation default location", () => {
+    return expect(setInitialLocation()).resolves.toEqual(DEFAULT_LOCATION);
+  });
+
+  test("setInitialLocation using lng lat", () => {
+    const [lng, lat] = [-122.09, 37.78];
+    const expected = {
+      bbox: [0, 0, 0, 0],
+      center: [0, 0],
+      geometry: {},
+      properties: {},
+      id: 1234,
+      title: "New place name",
+    };
+    return expect(setInitialLocation(lng, lat, "locagrid")).resolves.toEqual(
+      expected
+    );
+  });
+
+  test("setInitialLocation using featureId and boundary", () => {
+    const featureId = 1;
+    const expected = {
+      bbox: [0, 0, 0, 0],
+      center: [0, 0],
+      geometry: {},
+      properties: {},
+      id: featureId,
+      title: "New place name",
+    };
+    return expect(
+      setInitialLocation(null, null, "counties", 1)
+    ).resolves.toEqual(expected);
+  });
+});

--- a/src/routes/tools/_common/helpers.spec.js
+++ b/src/routes/tools/_common/helpers.spec.js
@@ -16,7 +16,7 @@ describe("tools/_common/helpers", () => {
       geometry: {},
       properties: {},
       id: 1234,
-      title: "New place name",
+      title: "LOCA Grid Cell",
     };
     return expect(setInitialLocation(lng, lat, "locagrid")).resolves.toEqual(
       expected

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -122,6 +122,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["featureId", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", $climvar.label],

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -58,7 +58,8 @@
   let ShareLink;
   let LearnMoreModal;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
 
   let learnMoreProps = {};
   let chartDescription = `<p>The colored lines on this visualization represent 
@@ -97,7 +98,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
       bookmark = makeBookmark({
@@ -164,6 +165,9 @@
 
   function changeLocation(e) {
     if (e.detail.boundaryId === "custom") {
+      // FIXME: this prevents the ShareLink from preventing a shareable URL
+      // because the boundary id will never be "custom" when a user clicks the
+      // share button.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
@@ -348,6 +352,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -14,7 +14,7 @@
     DEFAULT_STAT_PERIODS,
   } from "../_common/constants";
   import {
-    makeBookmark,
+    serialize,
     flattenData,
     groupDataByYear,
     formatDataForExport,
@@ -101,7 +101,7 @@
       shareLinkWarning = "Cannot create a share link for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
-      bookmark = makeBookmark({
+      bookmark = serialize({
         climvar: $climvarStore,
         scenario: $scenarioStore,
         models: $modelsStore.join(","),

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -125,7 +125,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
-      ["featureId", $location.id],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", $climvar.label],

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -97,6 +97,9 @@
   }
 
   async function loadShare() {
+    // TODO: after the custom boundary upload feature is implemented / fixed,
+    // set ShareLink's `errorMsg` prop when $boundary.id === "custom" as
+    // custom boundaries don't get encoded in the URL query params.
     bookmark = serialize({
       climvar: $climvarStore,
       scenario: $scenarioStore,

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -14,6 +14,7 @@
     DEFAULT_STAT_PERIODS,
   } from "../_common/constants";
   import {
+    makeBookmark,
     flattenData,
     groupDataByYear,
     formatDataForExport,
@@ -99,8 +100,14 @@
       bookmark = "Cannot create a bookmark for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
-      bookmark = `climvar=${$climvarStore}&scenario=${$scenarioStore}&models=${modelsStr}&lng=${lng}&lat=${lat}&boundary=${$boundary.id}`;
+      bookmark = makeBookmark({
+        climvar: $climvarStore,
+        scenario: $scenarioStore,
+        models: $modelsStore.join(","),
+        lng: lng.toFixed(6),
+        lat: lat.toFixed(6),
+        boundary: $boundary.id,
+      });
     }
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -145,17 +145,14 @@
 
   function changeScenario(e) {
     scenarioStore.set(e.detail.id);
-    console.log("scenario change");
   }
 
   function changeModels(e) {
     modelsStore.set(e.detail.selectedIds);
-    console.log("models change");
   }
 
   function changeClimvar(e) {
     climvarStore.set(e.detail.id);
-    console.log("climvar change");
   }
 
   function changeLocation(e) {
@@ -163,13 +160,15 @@
       // FIXME: this prevents the ShareLink from preventing a shareable URL
       // because the boundary id will never be "custom" when a user clicks the
       // share button.
+      // NOTE: custom boundary upload was removed in #236 so currenty this code
+      // does nothing. When re-implementing the custom boundary upload, this
+      // should be fixed.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
       locationStore.updateBoundary(e.detail.boundaryId);
       locationStore.updateLocation(e.detail.location);
     }
-    console.log("location change");
   }
 </script>
 

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -97,19 +97,13 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for an uploaded boundary";
-    } else {
-      const [lng, lat] = $location.center;
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        models: $modelsStore.join(","),
-        lng: lng.toFixed(6),
-        lat: lat.toFixed(6),
-        boundary: $boundary.id,
-      });
-    }
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      models: $modelsStore.join(","),
+      boundary: $boundary.id,
+      fid: $location.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;

--- a/src/routes/tools/annual-averages/index.svelte
+++ b/src/routes/tools/annual-averages/index.svelte
@@ -142,14 +142,14 @@
   async function initApp() {
     const { query } = $page;
     // Get initial configuration (from default or from url)
-    const { lat, lng, boundary, scenario, climvar, models, imperial } =
+    const { lat, lng, boundary, fid, scenario, climvar, models, imperial } =
       getInitialConfig(query);
     // Set intial values for stores
     climvarStore.set(climvar);
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     return;

--- a/src/routes/tools/annual-averages/index.svelte
+++ b/src/routes/tools/annual-averages/index.svelte
@@ -149,7 +149,7 @@
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
-    const loc = await setInitialLocation(+lng, +lat, boundary, fid);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     return;

--- a/src/routes/tools/annual-averages/index.svelte
+++ b/src/routes/tools/annual-averages/index.svelte
@@ -149,9 +149,14 @@
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     return;
   }
 

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -105,9 +105,7 @@
   $: formatFn = format(`.${$indicator.decimals}f`);
 
   $: indicatorTitle = $indicator.title.replace("Degree Days ", "");
-  $: frequencyLabel = frequencyList.find((d) => d.id === $frequencyStore).label;
-  $: frequencyLabel =
-    $frequencyStore === "A" ? frequencyLabel.replace("ly", "") : frequencyLabel;
+  $: frequencyLabel = setFrequencyLabel($frequencyStore);
   $: monthsLabel =
     $frequencyStore === "M" && $selectedMonthsStore ? getMonthsLabel() : "";
 
@@ -123,6 +121,11 @@
       chartTitle = $location.title;
     }
   });
+
+  function setFrequencyLabel(fstoreValue) {
+    let value = frequencyList.find((d) => d.id === fstoreValue).label;
+    return fstoreValue === "AS" ? value.replace("ly", "") : value;
+  }
 
   async function loadLearnMore({
     slugs = [],

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -76,7 +76,8 @@
   let ShareLink;
   let LearnMoreModal;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
 
   let learnMoreProps = {};
   let chartDescription = `<p>The colored lines on this visualization represent 
@@ -139,7 +140,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
       const modelsStr = $modelsStore.join(",");
@@ -153,6 +154,7 @@
         months: $selectedMonthsStore,
         lng,
         lat,
+        fid: $location.id,
         boundary: $boundary.id,
       });
     }
@@ -215,6 +217,12 @@
 
   function changeLocation(e) {
     if (e.detail.boundaryId === "custom") {
+      // FIXME: this prevents the ShareLink from preventing a shareable URL
+      // because the boundary id will never be "custom" when a user clicks the
+      // share button.
+      // NOTE: custom boundary upload was removed in #236 so currenty this code
+      // does nothing. When re-implementing the custom boundary upload, this
+      // should be fixed.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
@@ -455,6 +463,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -145,18 +145,14 @@
     if ($boundary.id === "custom") {
       shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
-      const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
       bookmark = serialize({
         climvar: $climvarStore,
         frequency: $frequencyStore,
         indicator: $indicatorsStore,
         scenario: $scenarioStore,
         threshold: $thresholdStore,
-        models: modelsStr,
+        models: $modelsStore.join(","),
         months: $selectedMonthsStore,
-        lng,
-        lat,
         fid: $location.id,
         boundary: $boundary.id,
       });

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -143,7 +143,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       const [lng, lat] = $location.center;
       const modelsStr = $modelsStore.join(",");

--- a/src/routes/tools/degree-days/index.svelte
+++ b/src/routes/tools/degree-days/index.svelte
@@ -199,9 +199,14 @@
     thresholdStore.set(threshold);
     frequencyStore.set(frequency);
     selectedMonthsStore.set(months);
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     return;
   }
 

--- a/src/routes/tools/degree-days/index.svelte
+++ b/src/routes/tools/degree-days/index.svelte
@@ -179,6 +179,7 @@
     const {
       lat,
       lng,
+      fid,
       boundary,
       indicator,
       scenario,
@@ -198,7 +199,7 @@
     thresholdStore.set(threshold);
     frequencyStore.set(frequency);
     selectedMonthsStore.set(months);
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     return;

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -52,7 +52,8 @@
   let ShareLink;
   let LearnMoreModal;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
 
   let learnMoreProps = {};
 
@@ -97,7 +98,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
       bookmark = serialize({
@@ -106,6 +107,7 @@
         period: $periodStore,
         lng,
         lat,
+        fid: $location.id,
         boundary: $boundary.id,
       });
     }
@@ -127,6 +129,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["featureId", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate variable", $climvar.label],
@@ -140,6 +143,12 @@
 
   function changeLocation(e) {
     if (e.detail.boundaryId === "custom") {
+      // FIXME: this prevents the ShareLink from preventing a shareable URL
+      // because the boundary id will never be "custom" when a user clicks the
+      // share button.
+      // NOTE: custom boundary upload was removed in #236 so currenty this code
+      // does nothing. When re-implementing the custom boundary upload, this
+      // should be fixed.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
@@ -213,6 +222,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -100,13 +100,10 @@
     if ($boundary.id === "custom") {
       shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
-      const [lng, lat] = $location.center;
       bookmark = serialize({
         climvar: $climvarStore,
         scenario: $scenarioStore,
         period: $periodStore,
-        lng,
-        lat,
         fid: $location.id,
         boundary: $boundary.id,
       });

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -129,7 +129,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
-      ["featureId", $location.id],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate variable", $climvar.label],

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -98,7 +98,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       const [lng, lat] = $location.center;
       bookmark = serialize({

--- a/src/routes/tools/extended-drought/index.svelte
+++ b/src/routes/tools/extended-drought/index.svelte
@@ -159,14 +159,14 @@
       period: DEFAULT_SELECTED_PERIOD,
     };
     // Get initial configuration (from default or from url)
-    const { lat, lng, boundary, scenario, climvar, period, imperial } =
+    const { lat, lng, fid, boundary, scenario, climvar, period, imperial } =
       getInitialConfig(query, config);
     // Set intial values for stores
     climvarStore.set(climvar);
     scenarioStore.set(scenario);
     unitsStore.set({ imperial });
     periodStore.set(period);
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     return;

--- a/src/routes/tools/extended-drought/index.svelte
+++ b/src/routes/tools/extended-drought/index.svelte
@@ -166,9 +166,14 @@
     scenarioStore.set(scenario);
     unitsStore.set({ imperial });
     periodStore.set(period);
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     return;
   }
 

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -116,7 +116,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       // TODO: add threshold value?
       bookmark = serialize({

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -10,6 +10,7 @@
     groupDataByYear,
     groupDataByDay,
     formatDataForExport,
+    serialize,
   } from "../_common/helpers";
 
   // Components
@@ -53,7 +54,9 @@
   let ShareLink;
   let LearnMoreModal;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
+
   let learnMoreProps = {};
   let metadata;
   let csvData;
@@ -113,11 +116,16 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
-      const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
-      bookmark = `climvar=${$climvarStore}&scenario=${$scenarioStore}&models=${modelsStr}&lng=${lng}&lat=${lat}&boundary=${$boundary.id}`;
+      // TODO: add threshold value?
+      bookmark = serialize({
+        climvar: $climvarStore,
+        scenario: $scenarioStore,
+        models: $modelsStore.join(","),
+        boundary: $boundary.id,
+        fid: $location.id,
+      });
     }
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
@@ -157,6 +165,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["featureId", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", `${$climvar.label} ${$indicator.label}`],
@@ -245,6 +254,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -165,7 +165,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
-      ["featureId", $location.id],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", `${$climvar.label} ${$indicator.label}`],

--- a/src/routes/tools/extreme-heat/index.svelte
+++ b/src/routes/tools/extreme-heat/index.svelte
@@ -188,14 +188,14 @@
   async function initApp() {
     const { query } = $page;
     // Get initial configuration (from default or from url)
-    const { lat, lng, boundary, scenario, climvar, models, imperial } =
+    const { lat, lng, fid, boundary, scenario, climvar, models, imperial } =
       getInitialConfig(query);
     // Set intial values for stores
     climvarStore.set(climvar);
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     const thresh98p = await getDefaultThreshold({

--- a/src/routes/tools/extreme-heat/index.svelte
+++ b/src/routes/tools/extreme-heat/index.svelte
@@ -205,7 +205,7 @@
     locationStore.updateBoundary(boundaryType);
     const thresh98p = await getDefaultThreshold({
       location,
-      boundary: { id: boundary },
+      boundary: { id: boundaryType },
       climvar: { id: climvar },
     });
     thresholdListStore.add(thresh98p, "98th Percentile");

--- a/src/routes/tools/extreme-heat/index.svelte
+++ b/src/routes/tools/extreme-heat/index.svelte
@@ -195,11 +195,16 @@
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     const thresh98p = await getDefaultThreshold({
-      location: loc,
+      location,
       boundary: { id: boundary },
       climvar: { id: climvar },
     });

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -146,7 +146,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       bookmark = serialize({
         climvar: $climvarStore,

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -211,7 +211,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
-      ["featureId", $location.id],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", `${indicatorLabel}`],

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -10,6 +10,7 @@
     groupDataByYear,
     groupDataByDay,
     formatDataForExport,
+    serialize,
   } from "../_common/helpers";
 
   // Components
@@ -31,7 +32,6 @@
     climvarStore,
     indicatorStore,
     thresholdStore,
-    thresholdTypeStore,
     durationStore,
     dataStore,
     returnPeriodStore,
@@ -62,7 +62,9 @@
   let ShareLink;
   let LearnMoreModal;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
+
   let learnMoreProps = {};
   let metadata;
   let csvData;
@@ -144,11 +146,22 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
-      const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
-      bookmark = `climvar=${$climvarStore}&scenario=${$scenarioStore}&duration=${$durationStore}&threshId=${$thresholdTypeStore}&models=${modelsStr}&lng=${lng}&lat=${lat}&boundary=${$boundary.id}`;
+      bookmark = serialize({
+        climvar: $climvarStore,
+        scenario: $scenarioStore,
+        duration: $durationStore,
+        /* BUG: when these values are loaded on initApp in index.svelte, the
+           data fetching breaks.
+        */
+        // threshType: $thresholdTypeStore,
+        // indicator: $indicator.id,
+        // aggregation: $aggregateFnStore,
+        models: $modelsStore.join(","),
+        boundary: $boundary.id,
+        fid: $location.id,
+      });
     }
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
@@ -198,6 +211,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["featureId", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate indicator", `${indicatorLabel}`],
@@ -213,6 +227,12 @@
 
   function changeLocation(e) {
     if (e.detail.boundaryId === "custom") {
+      // FIXME: this prevents the ShareLink from preventing a shareable URL
+      // because the boundary id will never be "custom" when a user clicks the
+      // share button.
+      // NOTE: custom boundary upload was removed in #236 so currenty this code
+      // does nothing. When re-implementing the custom boundary upload, this
+      // should be fixed.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
@@ -294,6 +314,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extreme-precipitation/_constants.js
+++ b/src/routes/tools/extreme-precipitation/_constants.js
@@ -23,12 +23,6 @@ export const DEFAULT_DURATION = 2;
 export const MIN_DURATION_DAYS = 1;
 export const MAX_DURATION_DAYS = 7;
 
-export const DEFAULT_INITIAL_CONFIG = {
-  ...INITIAL_CONFIG,
-  duration: DEFAULT_DURATION,
-  threshType: DEFAULT_THRESHOLD_TYPE,
-};
-
 export const DEFAULT_POLYGON_AGGREGATE_FUNCTION = "mean";
 export const POLYGON_AGGREGATE_FUNCTIONS = [
   {
@@ -40,6 +34,17 @@ export const POLYGON_AGGREGATE_FUNCTIONS = [
     label: "Maximum",
   },
 ];
+
+export const DEFAULT_INITIAL_CONFIG = {
+  ...INITIAL_CONFIG,
+  duration: DEFAULT_DURATION,
+  threshType: DEFAULT_THRESHOLD_TYPE,
+  /* BUG: when these values are loaded on initApp in index.svelte, the
+      data fetching breaks.
+  */
+  // aggregation: DEFAULT_POLYGON_AGGREGATE_FUNCTION,
+  // indicator: DEFAULT_CLIMATE_INDICATOR,
+};
 
 export const CLIMATE_VARIABLES = ["pr"];
 export const CLIMATE_INDICATORS = [

--- a/src/routes/tools/extreme-precipitation/index.svelte
+++ b/src/routes/tools/extreme-precipitation/index.svelte
@@ -296,12 +296,17 @@
     unitsStore.set({ imperial });
     durationStore.set(+duration);
     thresholdTypeStore.set(threshType);
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     const { params } = getQueryParams({
-      location: loc,
-      boundary: { id: boundary },
+      location,
+      boundary: { id: boundaryType },
       imperial: true,
       stat: $aggregateFnStore,
     });

--- a/src/routes/tools/extreme-precipitation/index.svelte
+++ b/src/routes/tools/extreme-precipitation/index.svelte
@@ -101,6 +101,7 @@
     returnPeriodStore,
     dataStore,
     aggregateFnStore,
+    indicatorStore,
   } from "./_store";
   import {
     getObserved,
@@ -123,8 +124,6 @@
   // Derived stores
   const { page } = sapperStores();
   const { location, boundary } = locationStore;
-  const { scenario } = scenarioStore;
-  const { intensity, events } = dataStore;
 
   // Local props
   let appReady = false;
@@ -273,20 +272,31 @@
     const {
       lat,
       lng,
+      fid,
       boundary,
       scenario,
       models,
       imperial,
       duration,
       threshType,
+      /* BUG: when these values are loaded on initApp in index.svelte, the
+          data fetching breaks.
+      */
+      // aggregation,
+      // indicator,
     } = getInitialConfig(query, DEFAULT_INITIAL_CONFIG);
+    /* BUG: when these values are loaded on initApp in index.svelte, the
+        data fetching breaks.
+    */
     // Set intial values for stores
+    // aggregateFnStore.set(aggregation);
+    // indicatorStore.set(indicator);
     scenarioStore.set(scenario);
     modelsStore.set(models);
     unitsStore.set({ imperial });
     durationStore.set(+duration);
     thresholdTypeStore.set(threshType);
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     const { params } = getQueryParams({

--- a/src/routes/tools/extreme-weather/_ExploreData.svelte
+++ b/src/routes/tools/extreme-weather/_ExploreData.svelte
@@ -16,7 +16,6 @@
   import {
     climvarStore,
     locationStore,
-    extremesStore,
     thresholdStore,
     doyStore,
     baseline,

--- a/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
+++ b/src/routes/tools/slr-coastal-inundation/_ExploreData.svelte
@@ -12,7 +12,7 @@
     dataLayersAugmentedStore,
   } from "./_store";
   import { getCSSProp } from "~/helpers/utilities";
-  import { makeBookmark } from "../_common/helpers";
+  import { serialize } from "../_common/helpers";
 
   import { Legend, StyleControl } from "~/components/tools/Map";
   import SettingsPanel from "./_SettingsPanel.svelte";
@@ -88,7 +88,7 @@
         .filter((d) => d.checked && !d.disabled)
         .map((d) => d.id)
         .join(",") || "none";
-    bookmark = makeBookmark({
+    bookmark = serialize({
       lat: lat.toFixed(6),
       lng: lng.toFixed(6),
       zoom: zoom.toFixed(4),

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -124,7 +124,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       bookmark = serialize({
         climvar: $climvarStore,

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -9,9 +9,9 @@
     flattenData,
     groupDataByYear,
     formatDataForExport,
+    serialize,
   } from "../_common/helpers";
 
-  import { serialize } from "~/helpers/utilities";
   import { getImgOverlayPath } from "./_data";
 
   import { Dashboard } from "~/components/tools/Partials";
@@ -63,7 +63,8 @@
   // reference to time slider component
   let timeSlider;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
 
   let learnMoreProps = {};
 
@@ -123,21 +124,18 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
-      const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
       bookmark = serialize({
         climvar: $climvarStore,
         scenario: $scenarioStore,
-        models: modelsStr,
+        models: $modelsStore.join(","),
         modelSingle: $modelSingleStore,
         year: $yearStore,
         month: $monthStore,
         duration: $durationStore,
-        lng,
-        lat,
         boundary: $boundary.id,
+        fid: $location.id,
       });
     }
     showShare = true;
@@ -158,6 +156,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["featureId", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate variable", $climvar.label],
@@ -175,6 +174,12 @@
 
   function changeLocation(e) {
     if (e.detail.boundaryId === "custom") {
+      // FIXME: this prevents the ShareLink from preventing a shareable URL
+      // because the boundary id will never be "custom" when a user clicks the
+      // share button.
+      // NOTE: custom boundary upload was removed in #236 so currenty this code
+      // does nothing. When re-implementing the custom boundary upload, this
+      // should be fixed.
       locationStore.updateBoundary("locagrid");
       locationStore.updateLocation(e.detail.location, true);
     } else {
@@ -304,6 +309,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -156,7 +156,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
-      ["featureId", $location.id],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate variable", $climvar.label],

--- a/src/routes/tools/snowpack/index.svelte
+++ b/src/routes/tools/snowpack/index.svelte
@@ -177,6 +177,7 @@
       lat,
       lng,
       boundary,
+      fid,
       scenario,
       climvar,
       models,
@@ -195,7 +196,7 @@
     yearStore.set(year);
     modelSingleStore.set(modelSingle);
     durationStore.set(+duration);
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
     return;

--- a/src/routes/tools/snowpack/index.svelte
+++ b/src/routes/tools/snowpack/index.svelte
@@ -196,9 +196,14 @@
     yearStore.set(year);
     modelSingleStore.set(modelSingle);
     durationStore.set(+duration);
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
     return;
   }
 

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -71,7 +71,8 @@
   // reference to time slider component
   let timeSlider;
 
-  let bookmark;
+  let bookmark = "";
+  let shareLinkWarning = "";
 
   let learnMoreProps = {};
 
@@ -139,7 +140,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      bookmark = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
     } else {
       const [lng, lat] = $location.center;
       const modelsStr = $modelsStore.join(",");
@@ -154,6 +155,7 @@
         lng,
         lat,
         boundary: $boundary.id,
+        fid: $location.id,
       });
     }
     showShare = true;
@@ -332,6 +334,7 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
+  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -140,7 +140,7 @@
 
   async function loadShare() {
     if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a bookmark for an uploaded boundary";
+      shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
       const [lng, lat] = $location.center;
       const modelsStr = $modelsStore.join(",");

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -142,18 +142,14 @@
     if ($boundary.id === "custom") {
       shareLinkWarning = "Cannot create a share link for a custom boundary";
     } else {
-      const [lng, lat] = $location.center;
-      const modelsStr = $modelsStore.join(",");
       bookmark = serialize({
         climvar: $climvarStore,
         scenario: $scenarioStore,
-        models: modelsStr,
+        models: $modelsStore.join(","),
         modelSingle: $modelSingleStore,
         year: $yearStore,
         month: $monthStore,
         simulation: $simulationStore,
-        lng,
-        lat,
         boundary: $boundary.id,
         fid: $location.id,
       });

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -176,6 +176,7 @@
     metadata = [
       ["boundary", $boundary.id],
       ["feature", $location.title],
+      ["feature id", $location.id],
       ["center", `${$location.center[0]}, ${$location.center[1]}`],
       ["scenario", $scenario.label],
       ["climate variable", $climvar.label],

--- a/src/routes/tools/wildfire/index.svelte
+++ b/src/routes/tools/wildfire/index.svelte
@@ -173,6 +173,7 @@
       lat,
       lng,
       boundary,
+      fid,
       scenario,
       climvar,
       models,
@@ -192,7 +193,7 @@
     modelSingleStore.set(modelSingle);
     simulationStore.set(simulation);
 
-    const loc = await setInitialLocation(+lng, +lat, boundary);
+    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
     locationStore.updateLocation(loc);
     locationStore.updateBoundary(boundary);
 

--- a/src/routes/tools/wildfire/index.svelte
+++ b/src/routes/tools/wildfire/index.svelte
@@ -193,9 +193,14 @@
     modelSingleStore.set(modelSingle);
     simulationStore.set(simulation);
 
-    const loc = await setInitialLocation(+lng, +lat, boundary, +fid);
-    locationStore.updateLocation(loc);
-    locationStore.updateBoundary(boundary);
+    const { location, boundaryType } = await setInitialLocation(
+      +lng,
+      +lat,
+      boundary,
+      +fid
+    );
+    locationStore.updateLocation(location);
+    locationStore.updateBoundary(boundaryType);
 
     const stateBoundary = await getStateBoundary();
     if (stateBoundary && stateBoundary.geometry) {


### PR DESCRIPTION
Fixes [a bug](https://trello.com/c/8JmopK9Q/198-bug-bookmarked-location-may-fail-to-load-desired-location-for-any-tool) with how tools set the initial value of the `locationStore` from URL query parameters when the tool first loads.

~~This also updates how the title for LOCA grid cells are displayed. The title is now created using the newly added "name" attribute on LOCA grid cell features (`feature.properties.name`) which is the centroid coordinates for a cell.~~ (moved to a separate PR #238)

~~As a bonus, this PR also fixes how the `StaticMap` component handles pending, error, and loaded async states when fetching the image URL. This is so that it will show an error message when failing to render (e.g. for Tehama County) and will re-display the loading message when the location changes.~~ (moved to a separate PR #237).