### PR TITLE
bug fix: disable upload boundary in Change Location modal

### DIFF
--- a/src/components/tools/Partials/ChangeLocationStation.svelte
+++ b/src/components/tools/Partials/ChangeLocationStation.svelte
@@ -12,12 +12,11 @@
   } from "~/helpers/geocode";
   import { logException, logGetFeatureErr } from "~/helpers/logging";
 
-  import { SelectBoundary, UploadBoundary } from "~/components/tools/Settings";
+  import { SelectBoundary } from "~/components/tools/Settings";
   import { Location } from "~/components/tools/Location";
   import { DEFAULT_LOCATION } from "~/routes/tools/_common/constants";
 
   export let location;
-  export let enableUpload = false;
   export let addStateBoundary = false;
   export let boundary;
   export let boundaryList;
@@ -218,16 +217,6 @@
     });
   }
 
-  function uploadBoundary(e) {
-    currentBoundary = { id: "custom" };
-    currentLoc = e.detail.location;
-  }
-
-  function clearUpload() {
-    currentLoc = location;
-    currentBoundary = boundary;
-  }
-
   function cancel() {
     currentLoc = location;
     currentBoundary = boundary;
@@ -328,12 +317,6 @@
           addStateBoundary="{addStateBoundary}"
           on:change="{updateBoundary}"
         />
-        {#if enableUpload}
-          <UploadBoundary
-            on:upload="{uploadBoundary}"
-            on:clear="{clearUpload}"
-          />
-        {/if}
       </div>
     {/if}
     <div class="change-location">

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -350,7 +350,6 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
-  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -463,7 +463,6 @@
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"
-  enableUpload="{false}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -222,7 +222,6 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
-  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -250,7 +250,6 @@
 <svelte:component
   this="{ChangeLocation}"
   bind:open="{showChangeLocation}"
-  enableUpload="{false}"
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -299,7 +299,6 @@
 <svelte:component
   this="{ChangeLocation}"
   bind:open="{showChangeLocation}"
-  enableUpload="{false}"
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -313,7 +313,6 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
-  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -341,7 +341,6 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
-  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 


### PR DESCRIPTION
This is a temporarily fix for the broken custom boundary upload feature in tools that use the `ChangeLocationStation` component in their settings panel. It removes the ability for a user to use a custom boundary polygon as a location.

https://trello.com/c/59uIUgqU