### PR TITLE
StaticMap component: feature & bug fix

### DIFF
--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -66,6 +66,7 @@
     )}`;
   }
 
+  // FIXME: this creates invalid geometries for some boundaries, e.g. Tehama County
   function createOverlay(geojson, tolerance = 0.005) {
     const overlay = encodeURIComponent(JSON.stringify(geojson));
     if (overlay.length < 7500) {

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -38,20 +38,22 @@
   $: if (src) image.src = src;
   $: if (location) state = "pending";
 
+  function handleException() {
+    const exception = `StaticMap failed to render for ${
+      location && location.title
+    }. Fid: ${location && location.id}`;
+    state = "error";
+    logException(exception);
+    console.warn(exception);
+  }
+
   onMount(() => {
     MapWrapper = useButton ? Button : Tile;
     image = new Image();
     image.onload = () => {
       state = "loaded";
     };
-    image.onerror = () => {
-      state = "error";
-      logException(
-        `StaticMap image failed for ${location && location.title} at ${
-          location && location.center && location.center.join(",")
-        }`
-      );
-    };
+    image.onerror = handleException;
   });
 
   function createSrcUrl({ overlay, bounds, params }) {
@@ -123,9 +125,8 @@
         } else {
           getPolygonImgSrc(location);
         }
-      } catch (error) {
-        console.warn(error);
-        state = "error";
+      } catch {
+        handleException();
       }
     },
     200,

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -21,7 +21,7 @@
   const { accessToken } = mapboxgl;
   const MAX_IMG_HEIGHT = 250;
 
-  let imageWrapper;
+  let MapWrapper;
   let image;
   let state = "pending";
   let width;
@@ -39,7 +39,7 @@
   $: if (location) state = "pending";
 
   onMount(() => {
-    imageWrapper = useButton ? Button : Tile;
+    MapWrapper = useButton ? Button : Tile;
     image = new Image();
     image.onload = () => {
       state = "loaded";
@@ -167,7 +167,7 @@
 </style>
 
 <div bind:clientWidth="{width}" aria-live="polite">
-  <svelte:component this="{imageWrapper}" on:click aria-label="{ariaLabel}">
+  <svelte:component this="{MapWrapper}" on:click aria-label="{ariaLabel}">
     {#if state === "loaded"}
       <img
         {...$$restProps}

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -108,10 +108,14 @@
     };
     const bounds = "auto";
     const params = { access_token: accessToken, padding };
-    // The Mapbox Static Images API only accepts requests that are 8,192 or fewer characters long.
-    // Reduce coordinate precision
-    const truncatedGeojson = truncate(geojson, { precision: 4 });
-    // Simplify geometry
+    // The Mapbox Static Images API only accepts requests that are 8,192 or
+    // fewer characters long. So we...
+    // 1. reduce coordinate precision
+    const truncatedGeojson = truncate(geojson, {
+      precision: 4,
+      coordinates: 2,
+    });
+    // 2. simplify the geometry
     const overlay = createOverlay(truncatedGeojson);
     createSrcUrl({ overlay, bounds, params });
   }

--- a/src/components/tools/Location/StaticMap.svelte
+++ b/src/components/tools/Location/StaticMap.svelte
@@ -35,7 +35,7 @@
   $: if (valid && width && location && location.geometry) {
     handleLocation(location);
   }
-  $: if (src) image.src = src;
+  $: if (image && src) image.src = src;
   $: if (location) state = "pending";
 
   function handleException() {


### PR DESCRIPTION
Updates to the `StaticMap` component:
- Enables wrapping the locator map image in either a button or div (the latter for preventing interaction, for example with use in the LCCS tool "explore" page).
- Fixes the loading, loaded, and error states so that the error message will display when rendering the map fails (e.g. for boundaries like Tehama County) and that the loading message will display when the location is changed.

**NOTE:** this PR makes some temporary adjustments to this component but does not fix [the issue](https://trello.com/c/cKnxzgSN) which causes it to occasionally not render.