### PR TITLE
feature: use native title for loca grid cells in tool headers

### DIFF
--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -45,6 +45,7 @@ export const searchBoundaryLayer = async (searchStr, boundaryId) => {
   const searchParams = {
     srs: 4326,
     search: searchStr,
+    v: 1, // cache bust 2022-05-09
   };
   const [response, error] = await handleXHR(fetchData(url, searchParams));
   if (error) {
@@ -60,6 +61,7 @@ export const getBoundaryPolygon = async (coords, boundaryId) => {
     precision: 4,
     //intersects: `{"type":"Point","coordinates":[${coords[0]},${coords[1]}]}`,
     intersects: `Point(${coords[0]} ${coords[1]})`,
+    v: 1, // cache bust 2022-05-09
   };
   const [response, error] = await handleXHR(fetchData(url, searchParams));
   if (error) {
@@ -70,7 +72,11 @@ export const getBoundaryPolygon = async (coords, boundaryId) => {
 
 export const getFeatureById = async (id, layerId) => {
   const url = `${apiEndpoint}/${layerId}/${id}`;
-  const [response, error] = await handleXHR(fetchData(url, {}));
+  const [response, error] = await handleXHR(
+    fetchData(url, {
+      v: 1, // cache bust 2022-05-09
+    })
+  );
   if (error) {
     throw new Error(error.message);
   }
@@ -201,6 +207,7 @@ export const getNearestFeature = async (lng, lat, layerId) => {
     srs: 4326,
     precision: 4,
     distance_to: `POINT(${lng} ${lat})`,
+    v: 1, // cache bust 2022-05-09
   };
   const [response, error] = await handleXHR(fetchData(url, params));
   if (error) {

--- a/src/helpers/geocode.js
+++ b/src/helpers/geocode.js
@@ -80,7 +80,9 @@ export const getFeatureById = async (id, layerId) => {
 export const getTitle = (feature, layerId, placeName) => {
   switch (layerId) {
     case "locagrid":
-      return placeName.replace(", United States", "");
+      return feature.properties && feature.properties.name
+        ? `LOCA Grid Cell ${feature.properties.name}`
+        : "LOCA Grid Cell";
     case "counties":
       return `${feature.properties.name} County, ${feature.properties.state_name}`;
     case "censustracts":

--- a/src/routes/tools/_common/constants.js
+++ b/src/routes/tools/_common/constants.js
@@ -8,8 +8,8 @@ import scenarios from "~/helpers/climate-scenarios";
 import boundaries from "~/helpers/mapbox-layers";
 
 export const DEFAULT_LOCATION = {
-  id: "37907",
-  title: "240 32nd Street, Sacramento, California 95816",
+  id: 37907,
+  title: "LOCA Grid Cell -121.46875, 38.59375",
   geometry: {
     type: "Polygon",
     coordinates: [

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -324,20 +324,6 @@ export async function setInitialLocation(lng, lat, boundary) {
     console.warn(error);
   }
 
-  if (boundary === "locagrid") {
-    let placeName = DEFAULT_LOCAGRIDCELL_TITLE;
-    try {
-      const result = await reverseGeocode(`${lng}, ${lat}`);
-      if (result && result.features && result.features.length) {
-        placeName = result.features[0].place_name;
-      }
-    } catch (error) {
-      console.warn(error);
-    } finally {
-      loc.title = getTitle(loc, boundary, placeName);
-    }
-  }
-
   return loc;
 }
 


### PR DESCRIPTION
Makes use of the `name` attribute that was recently added to LOCA grid cell features in the Cal-Adapt API. Display names now appear in the tool headers in the form of "LOCA Grid Cell `<lng>`, `<lat>`".