### PR TITLE
bug fix: custom boundary upload in all tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "jest": "^27.5.1",
         "layercake": "^4.0.3",
         "lint-staged": "^11.1.2",
+        "lodash.clonedeep": "^4.5.0",
         "marked": "^1.2.7",
         "node-sass": "^6.0.1",
         "prettier": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "jest": "^27.5.1",
     "layercake": "^4.0.3",
     "lint-staged": "^11.1.2",
+    "lodash.clonedeep": "^4.5.0",
     "marked": "^1.2.7",
     "node-sass": "^6.0.1",
     "prettier": "^2.0.0",

--- a/src/components/tools/Partials/ChangeLocationStation.svelte
+++ b/src/components/tools/Partials/ChangeLocationStation.svelte
@@ -12,11 +12,12 @@
   } from "~/helpers/geocode";
   import { logException, logGetFeatureErr } from "~/helpers/logging";
 
-  import { SelectBoundary } from "~/components/tools/Settings";
+  import { SelectBoundary, UploadBoundary } from "~/components/tools/Settings";
   import { Location } from "~/components/tools/Location";
   import { DEFAULT_LOCATION } from "~/routes/tools/_common/constants";
 
   export let location;
+  export let enableUpload = false;
   export let addStateBoundary = false;
   export let boundary;
   export let boundaryList;
@@ -217,6 +218,16 @@
     });
   }
 
+  function uploadBoundary(e) {
+    currentBoundary = { id: "custom" };
+    currentLoc = e.detail.location;
+  }
+
+  function clearUpload() {
+    currentLoc = location;
+    currentBoundary = boundary;
+  }
+
   function cancel() {
     currentLoc = location;
     currentBoundary = boundary;
@@ -317,6 +328,12 @@
           addStateBoundary="{addStateBoundary}"
           on:change="{updateBoundary}"
         />
+        {#if enableUpload}
+          <UploadBoundary
+            on:upload="{uploadBoundary}"
+            on:clear="{clearUpload}"
+          />
+        {/if}
       </div>
     {/if}
     <div class="change-location">

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -8,20 +8,30 @@
     handle,
     convertFileToGeojson,
     validateShape,
-  } from "./../../../helpers/utilities";
-  import { formatFeature } from "./../../../helpers/geocode";
+  } from "~/helpers/utilities";
+  import { formatFeature } from "~/helpers/geocode";
 
   const dispatch = createEventDispatcher();
+
+  const labelDescription = `Select a boundary from the dropdown list or upload
+    your project area. Supported formats - zipped Shapefile, GeoJSON, KML.`;
+
+  const statuses = {
+    uploading: "uploading",
+    edit: "edit",
+    complete: "complete",
+  };
+
   const fileUploadProps = {
     labelTitle: "",
-    labelDescription:
-      "Select a boundary from the dropdown list or upload your project area. Supported formats - zipped shapefile, GeoJSON, KML, WKT.",
+    labelDescription,
     buttonLabel: "Upload File",
     accept: [".zip", ".json", ".geojson", ".kml"],
     iconDescription: "Clear file",
-    id: "Upload",
-    errorSubject: "",
-    errorBody: "",
+    id: "upload-custom-boundary",
+    errorSubject: "", // not actually a FileUploader prop
+    errorBody: "", // not actually a FileUploader prop
+    status: statuses.uploading,
   };
 
   let fileUploader;
@@ -32,7 +42,7 @@
 
   export function clearFiles() {
     fileUploader.clearFiles();
-    fileUploadProps.status = "";
+    fileUploadProps.status = statuses.uploading;
     fileUploadProps.errorSubject = "";
     fileUploadProps.errorBody = "";
     fileUploadProps.invalid = false;
@@ -40,65 +50,46 @@
   }
 
   function handleLoading() {
-    fileUploadProps.status = "uploading";
+    fileUploadProps.status = statuses.uploading;
     fileUploadProps.invalid = false;
     fileUploadProps.errorSubject = "";
     fileUploadProps.errorBody = "";
   }
 
-  function handleValidityError(error) {
-    fileUploadProps.status = "edit";
-    fileUploadProps.invalid = true;
-    fileUploadProps.errorSubject = "Error";
-    fileUploadProps.errorBody = String(error).split(":")[1];
+  /** @type {(error: Error | string, title: "Error" | "Warning") => void} */
+  function handleValidityError(error, title = "Error") {
+    fileUploadProps.status = statuses.edit;
+    fileUploadProps.invalid = title === "Error";
+    fileUploadProps.errorSubject = title;
+    fileUploadProps.errorBody =
+      typeof error === "object" ? error.message : error;
   }
 
-  function handleGeoJsonError(data, error) {
-    if (data && data.features && data.features.length) {
-      fileUploadProps.errorSubject = "Warning";
-      fileUploadProps.errorBody =
-        "We can fetch data for this area but cannot display it on the inset map.";
-      // FIXME: support this use case???
-      // const location = formatFeature(geojson.features[0], "custom");
-      // location.title = file.name;
-      // dispatch("upload", { location });
-    } else {
-      fileUploadProps.errorSubject = "Error";
-      fileUploadProps.errorBody =
-        "Something went wrong, please contact support.";
-      fileUploadProps.invalid = true;
-    }
-  }
-
+  /** @type {(data: GeoJSON) => Feature | null } */
   function handleGeoJsonSuccess(data) {
     if (data.type === "FeatureCollection") {
       if (data.features.length) {
         const flag = data.features.length > 1;
-        fileUploadProps.status = flag ? "edit" : "complete";
+        fileUploadProps.status = statuses.complete;
         fileUploadProps.errorSubject = flag ? "Warning" : "";
         fileUploadProps.errorBody = flag
-          ? "The uploaded file has more than 1 geometry. The tool can display fetch data for only 1 geometry at a time."
+          ? `The uploaded file has more than 1 geometry. The tool can display
+            data for only 1 geometry at a time.`
           : "";
-        fileUploadProps.invalid = flag;
+        fileUploadProps.invalid = false;
         return data.features[0];
       } else {
-        fileUploadProps.status = "edit";
-        fileUploadProps.invalid = true;
-        fileUploadProps.errorSubject = "Error";
-        fileUploadProps.errorBody = "Uploaded file contains no features.";
+        handleValidityError("The uploaded file contains no features.");
         return null;
       }
     } else if (data.type === "Feature") {
+      fileUploadProps.status = statuses.complete;
       fileUploadProps.errorSubject = "";
       fileUploadProps.errorBody = "";
       fileUploadProps.invalid = false;
       return data;
     } else {
-      fileUploadProps.status = "edit";
-      fileUploadProps.invalid = true;
-      fileUploadProps.errorSubject = "Error";
-      fileUploadProps.errorBody =
-        "Must be a GeoJSON FeatureCollection or Feature.";
+      handleValidityError("Must be a GeoJSON FeatureCollection or Feature.");
       return null;
     }
   }
@@ -115,47 +106,57 @@
       return;
     }
 
-    // Try converting the uploaded boundary to (Geo)JSON format
+    // Try converting the uploaded boundary to JSON format
     const [geojson, geojsonError] = await handle(convertFileToGeojson(file));
+    const isValidGeoJson = typeof geojson === "object" && "type" in geojson;
 
     if (geojsonError) {
-      handleGeoJsonError(geojson, geojsonError);
-      return;
+      if (isValidGeoJson) {
+        handleValidityError(
+          `We can fetch data for this area, but the boundary may not display on
+          the location map.`,
+          "Warning"
+        );
+        // NOTE: we don't early return here so that the custom boundary may still be used
+      } else {
+        handleValidityError(geojsonError);
+        return;
+      }
     }
 
-    if (typeof geojson === "object" && "type" in geojson) {
+    if (isValidGeoJson) {
       const feature = handleGeoJsonSuccess(geojson);
       if (feature) {
         const location = formatFeature(feature, "custom");
         location.title = file.name;
         dispatch("upload", { location });
-      } else {
-        handleGeoJsonError(geojson);
       }
-    } else {
-      handleGeoJsonError(geojson);
     }
   }
 </script>
 
 <style>
-  :global(.bx--file__selected-file) {
+  div :global(.bx--file__selected-file) {
     background: #f1f4f8;
   }
-  :global(.bx--file__selected-file .bx--file-filename) {
+
+  div :global(.bx--file__selected-file .bx--file-filename) {
     margin-bottom: 0;
   }
 </style>
 
-<FileUploader
-  {...fileUploadProps}
-  kind="tertiary"
-  bind:this="{fileUploader}"
-  on:add="{({ detail }) => {
-    processUpload(detail[0]);
-  }}"
-  on:click="{clearFiles}"
-/>
-{#if fileUploadProps.errorSubject === "Warning" || fileUploadProps.errorSubject === "Error"}
-  <span>{fileUploadProps.errorBody}</span>
-{/if}
+<div>
+  <FileUploader
+    {...fileUploadProps}
+    kind="tertiary"
+    bind:this="{fileUploader}"
+    on:add="{({ detail }) => {
+      processUpload(detail[0]);
+    }}"
+    on:click="{clearFiles}"
+  />
+
+  {#if fileUploadProps.errorSubject}
+    <span>{fileUploadProps.errorSubject}: {fileUploadProps.errorBody}</span>
+  {/if}
+</div>

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -30,7 +30,7 @@
     fileUploader.clearFiles();
   }
 
-  function clearFiles() {
+  export function clearFiles() {
     fileUploader.clearFiles();
     fileUploadProps.status = "";
     fileUploadProps.errorSubject = "";
@@ -39,50 +39,101 @@
     dispatch("clear");
   }
 
-  async function processUpload(file) {
-    console.log("....uploadng");
+  function handleLoading() {
     fileUploadProps.status = "uploading";
     fileUploadProps.invalid = false;
     fileUploadProps.errorSubject = "";
     fileUploadProps.errorBody = "";
-    const [validity, validityError] = await handleXHR(validateShape(file));
-    if (validityError) {
-      fileUploadProps.status = "edit";
-      fileUploadProps.invalid = true;
-      fileUploadProps.errorSubject = "Error";
-      fileUploadProps.errorBody = String(validityError).split(":")[1];
-      return;
-    }
-    fileUploadProps.status = "complete";
-    const [geojson, geojsonError] = await handle(convertFileToGeojson(file));
+  }
 
-    if (geojson && !geojsonError && geojson.features.length === 1) {
-      fileUploadProps.errorSubject = "";
-      fileUploadProps.errorBody = "";
-      fileUploadProps.invalid = false;
-      const location = formatFeature(geojson.features[0], "custom");
-      location.title = file.name;
-      dispatch("upload", { location });
-      return;
-    }
+  function handleValidityError(error) {
+    fileUploadProps.status = "edit";
+    fileUploadProps.invalid = true;
+    fileUploadProps.errorSubject = "Error";
+    fileUploadProps.errorBody = String(error).split(":")[1];
+  }
 
-    if (geojson && geojsonError && geojson.features.length === 1) {
+  function handleGeoJsonError(data, error) {
+    if (data && data.features && data.features.length) {
       fileUploadProps.errorSubject = "Warning";
       fileUploadProps.errorBody =
         "We can fetch data for this area but cannot display it on the inset map.";
-      const location = formatFeature(geojson.features[0], "custom");
-      location.title = file.name;
-      dispatch("upload", { location });
-      return;
+      // FIXME: support this use case???
+      // const location = formatFeature(geojson.features[0], "custom");
+      // location.title = file.name;
+      // dispatch("upload", { location });
+    } else {
+      fileUploadProps.errorSubject = "Error";
+      fileUploadProps.errorBody =
+        "Something went wrong, please contact support.";
+      fileUploadProps.invalid = true;
     }
+  }
 
-    if (geojson && geojson.features.length > 1) {
+  function handleGeoJsonSuccess(data) {
+    if (data.type === "FeatureCollection") {
+      if (data.features.length) {
+        const flag = data.features.length > 1;
+        fileUploadProps.status = flag ? "edit" : "complete";
+        fileUploadProps.errorSubject = flag ? "Warning" : "";
+        fileUploadProps.errorBody = flag
+          ? "The uploaded file has more than 1 geometry. The tool can display fetch data for only 1 geometry at a time."
+          : "";
+        fileUploadProps.invalid = flag;
+        return data.features[0];
+      } else {
+        fileUploadProps.status = "edit";
+        fileUploadProps.invalid = true;
+        fileUploadProps.errorSubject = "Error";
+        fileUploadProps.errorBody = "Uploaded file contains no features.";
+        return null;
+      }
+    } else if (data.type === "Feature") {
+      fileUploadProps.errorSubject = "";
+      fileUploadProps.errorBody = "";
+      fileUploadProps.invalid = false;
+      return data;
+    } else {
       fileUploadProps.status = "edit";
       fileUploadProps.invalid = true;
       fileUploadProps.errorSubject = "Error";
       fileUploadProps.errorBody =
-        "The uploaded file has more than 1 geometry. The tool can display fetch data for only 1 geometry at a time.";
+        "Must be a GeoJSON FeatureCollection or Feature.";
+      return null;
+    }
+  }
+
+  async function processUpload(file) {
+    handleLoading();
+
+    // NOTE: this only validates the file against the Cal-Adapt API.
+    // The response is not used for anything.
+    const [, validityError] = await handleXHR(validateShape(file));
+
+    if (validityError) {
+      handleValidityError(validityError);
       return;
+    }
+
+    // Try converting the uploaded boundary to (Geo)JSON format
+    const [geojson, geojsonError] = await handle(convertFileToGeojson(file));
+
+    if (geojsonError) {
+      handleGeoJsonError(geojson, geojsonError);
+      return;
+    }
+
+    if (typeof geojson === "object" && "type" in geojson) {
+      const feature = handleGeoJsonSuccess(geojson);
+      if (feature) {
+        const location = formatFeature(feature, "custom");
+        location.title = file.name;
+        dispatch("upload", { location });
+      } else {
+        handleGeoJsonError(geojson);
+      }
+    } else {
+      handleGeoJsonError(geojson);
     }
   }
 </script>

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -37,14 +37,11 @@
     status: statuses.uploading,
   };
 
-  let fileUploader; // ref to component
-
-  $: if (fileUploader) {
-    fileUploader.clearFiles();
-  }
+  // ref to FileLoader component
+  let ref;
 
   export function clearFiles() {
-    fileUploader.clearFiles();
+    ref.clearFiles();
     fileUploadProps.status = statuses.uploading;
     fileUploadProps.errorSubject = "";
     fileUploadProps.errorBody = "";
@@ -152,7 +149,7 @@
   <FileUploader
     {...fileUploadProps}
     kind="tertiary"
-    bind:this="{fileUploader}"
+    bind:this="{ref}"
     bind:files
     on:add="{({ detail }) => {
       processUpload(detail[0]);

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -17,7 +17,7 @@
     labelDescription:
       "Select a boundary from the dropdown list or upload your project area. Supported formats - zipped shapefile, GeoJSON, KML, WKT.",
     buttonLabel: "Upload File",
-    accept: [".zip", ".json", ".geojson", ".kml", ".wkt"],
+    accept: [".zip", ".json", ".geojson", ".kml"],
     iconDescription: "Clear file",
     id: "Upload",
     errorSubject: "",

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -11,6 +11,9 @@
   } from "~/helpers/utilities";
   import { formatFeature } from "~/helpers/geocode";
 
+  /** the files attribute from the file input  */
+  export let files = [];
+
   const dispatch = createEventDispatcher();
 
   const labelDescription = `Select a boundary from the dropdown list or upload
@@ -34,7 +37,7 @@
     status: statuses.uploading,
   };
 
-  let fileUploader;
+  let fileUploader; // ref to component
 
   $: if (fileUploader) {
     fileUploader.clearFiles();
@@ -150,6 +153,7 @@
     {...fileUploadProps}
     kind="tertiary"
     bind:this="{fileUploader}"
+    bind:files
     on:add="{({ detail }) => {
       processUpload(detail[0]);
     }}"

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -157,7 +157,10 @@
     on:click="{clearFiles}"
   />
 
-  {#if fileUploadProps.errorSubject}
-    <span>{fileUploadProps.errorSubject}: {fileUploadProps.errorBody}</span>
+  {#if fileUploadProps.errorSubject || fileUploadProps.errorBody}
+    <span
+      >{`${fileUploadProps.errorSubject}: ` || ""}{fileUploadProps.errorBody ||
+        ""}</span
+    >
   {/if}
 </div>

--- a/src/components/tools/Settings/UploadBoundary.svelte
+++ b/src/components/tools/Settings/UploadBoundary.svelte
@@ -12,7 +12,7 @@
   } from "~/helpers/utilities";
   import { formatFeature } from "~/helpers/geocode";
 
-  /** the files attribute from the file input  */
+  /** @type {?File[]} - the files attribute from the file input  */
   export let files = [];
 
   const dispatch = createEventDispatcher();
@@ -95,6 +95,7 @@
     }
   }
 
+  /** @type {(file: File) => void } */
   async function processUpload(file) {
     handleLoading();
 
@@ -137,10 +138,11 @@
     }
   }
 
-  function isValidGeoJson(geojson) {
-    if (typeof geojson === "object" && "type" in geojson) {
+  /** @type { (data: any) => boolean } */
+  function isValidGeoJson(data) {
+    if (typeof data === "object" && "type" in data) {
       try {
-        return isWgs84(geojson);
+        return isWgs84(data);
       } catch (error) {
         console.log(error);
       }
@@ -148,8 +150,9 @@
     return false;
   }
 
-  function isWgs84(data) {
-    const [xMin, yMin, xMax, yMax] = bbox(data);
+  /** @type { (geojson: GeoJSON ) => boolean } */
+  function isWgs84(geojson) {
+    const [xMin, yMin, xMax, yMax] = bbox(geojson);
     if (xMin < -180 || xMax > 180) {
       return false;
     }

--- a/src/helpers/mapbox-layers.js
+++ b/src/helpers/mapbox-layers.js
@@ -9,7 +9,8 @@ const translinesExpr = ["to-number", ["get", "kV_Sort"]];
 //const powerplantsExpr = ["to-number", ["get", "MW"]];
 const cesScore = ["get", "ces_3_0_percentile_range"];
 
-const data = [
+// NOTE: "custom" boundaries are not included in this list but are an option in some tools.
+export default [
   {
     id: "locagrid",
     type: "line",
@@ -484,5 +485,3 @@ const data = [
     },
   },
 ];
-
-export default data;

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -443,6 +443,7 @@ export async function convertFileToGeojson(file) {
   const { name } = file;
   const extension = name.split(".")[1];
   let data;
+  // TODO: support WKT format?
   if (extension === "zip") {
     const archive = await file.arrayBuffer();
     data = await shp(archive);

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -4,12 +4,13 @@ import config from "./api-config";
 import shp from "shpjs";
 import tj from "@mapbox/togeojson";
 import throttle from "lodash.throttle";
+import cloneDeep from "lodash.clonedeep";
 import { range } from "d3-array";
 import leftPad from "just-left-pad";
 
 const { apiEndpoint } = config.env.production;
 
-export { throttle, leftPad };
+export { cloneDeep, throttle, leftPad };
 
 export const parseDateIso = utcParse("%Y-%m-%dT%H:%M:%S%Z");
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -442,20 +442,17 @@ export async function validateShape(file) {
 export async function convertFileToGeojson(file) {
   const { name } = file;
   const extension = name.split(".")[1];
-  let data;
-  // TODO: support WKT format?
   if (extension === "zip") {
     const archive = await file.arrayBuffer();
-    data = await shp(archive);
+    return await shp(archive);
   } else if (extension === "kml") {
     const text = await file.text();
     const xml = new DOMParser().parseFromString(text, "text/xml");
-    data = tj.kml(xml);
+    return tj.kml(xml);
   } else {
     const text = await file.text();
-    data = JSON.parse(text);
+    return JSON.parse(text);
   }
-  return data;
 }
 
 /**

--- a/src/routes/tools/_common/constants.js
+++ b/src/routes/tools/_common/constants.js
@@ -41,6 +41,10 @@ export const DEFAULT_BOUNDARIES = boundaries
     };
   });
 
+export const PERMITTED_BOUNDARY_TYPES = new Set(
+  DEFAULT_BOUNDARIES.map((d) => d.id)
+);
+
 export const SMALL_SCALE_BOUNDARIES = boundaries
   .filter((d) =>
     [

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -8,7 +8,12 @@ import {
   DEFAULT_LOCATION,
   DEFAULT_BOUNDARIES,
 } from "./constants";
-import { isLeapYear, isValidNumber, serialize } from "~/helpers/utilities";
+import {
+  cloneDeep,
+  isLeapYear,
+  isValidNumber,
+  serialize,
+} from "~/helpers/utilities";
 import { getFeature, getFeatureById } from "~/helpers/geocode";
 import { logException } from "~/helpers/logging";
 
@@ -17,6 +22,26 @@ export { serialize };
 export const PERMITTED_BOUNDARY_TYPES = new Set(
   DEFAULT_BOUNDARIES.map((d) => d.id)
 );
+
+/**
+ * createCustomBoundaryObject
+ * @param {object} location - the formatted location datum
+ * @returns {object} - boundary object for custom boundary type
+ */
+export function createCustomBoundaryObject(location) {
+  const boundary = cloneDeep(DEFAULT_BOUNDARIES[0]);
+  boundary.id = "custom";
+  boundary.metadata.title = location.title;
+  boundary.metadata.placeholder = "custom";
+  boundary.source = {
+    type: "geojson",
+    data: {
+      type: "Feature",
+      geometry: { ...location.geometry },
+    },
+  };
+  return boundary;
+}
 
 /**
  * Groups data for 2 or more timeseries by year, outputs a single timeseries with

--- a/src/routes/tools/_common/helpers.js
+++ b/src/routes/tools/_common/helpers.js
@@ -7,6 +7,7 @@ import {
   PRIORITY_10_MODELS,
   DEFAULT_LOCATION,
   DEFAULT_BOUNDARIES,
+  PERMITTED_BOUNDARY_TYPES,
 } from "./constants";
 import {
   cloneDeep,
@@ -18,10 +19,6 @@ import { getFeature, getFeatureById } from "~/helpers/geocode";
 import { logException } from "~/helpers/logging";
 
 export { serialize };
-
-export const PERMITTED_BOUNDARY_TYPES = new Set(
-  DEFAULT_BOUNDARIES.map((d) => d.id)
-);
 
 /**
  * createCustomBoundaryObject

--- a/src/routes/tools/_common/stores.js
+++ b/src/routes/tools/_common/stores.js
@@ -90,6 +90,13 @@ export const locationStore = (() => {
   const { update, subscribe } = store;
   return {
     subscribe,
+    updateAll: ({ boundaryId, location, isUpload = false }) =>
+      update((store) => {
+        store.isUpload = isUpload;
+        store.location = location;
+        store.boundaryId = boundaryId;
+        return store;
+      }),
     updateLocation: (location, isUpload = false) =>
       update((store) => {
         store.location = location;

--- a/src/routes/tools/_common/stores.js
+++ b/src/routes/tools/_common/stores.js
@@ -1,7 +1,7 @@
 import { writable, derived } from "svelte/store";
 import scenarios from "~/helpers/climate-scenarios";
 import boundaries from "~/helpers/mapbox-layers";
-import { cloneDeep } from "~/helpers/utilities";
+import { createCustomBoundaryObject } from "./helpers";
 
 /**
  *
@@ -120,15 +120,7 @@ export const locationStore = (() => {
         let selected;
         if (boundaryType === "custom" && "geometry" in location) {
           // NOTE: there is no "custom" boundary type in boundaries so we create it here.
-          selected = cloneDeep(boundaries.find((d) => d.id === "locagrid"));
-          selected.id = "custom";
-          selected.source = {
-            type: "geojson",
-            data: {
-              type: "Feature",
-              geometry: { ...location.geometry },
-            },
-          };
+          selected = createCustomBoundaryObject(location);
         } else {
           selected = boundaries.find((d) => d.id === boundaryType);
         }

--- a/src/routes/tools/_common/stores.js
+++ b/src/routes/tools/_common/stores.js
@@ -1,6 +1,7 @@
 import { writable, derived } from "svelte/store";
-import scenarios from "../../../helpers/climate-scenarios";
-import boundaries from "../../../helpers/mapbox-layers";
+import scenarios from "~/helpers/climate-scenarios";
+import boundaries from "~/helpers/mapbox-layers";
+import { cloneDeep } from "~/helpers/utilities";
 
 /**
  *
@@ -107,7 +108,23 @@ export const locationStore = (() => {
     },
     get boundary() {
       return derived(store, ($store) => {
-        const selected = boundaries.find((d) => d.id === $store.boundaryId);
+        const boundaryType = $store.boundaryId;
+        const location = $store.location;
+        let selected;
+        if (boundaryType === "custom" && "geometry" in location) {
+          // NOTE: there is no "custom" boundary type in boundaries so we create it here.
+          selected = cloneDeep(boundaries.find((d) => d.id === "locagrid"));
+          selected.id = "custom";
+          selected.source = {
+            type: "geojson",
+            data: {
+              type: "Feature",
+              geometry: { ...location.geometry },
+            },
+          };
+        } else {
+          selected = boundaries.find((d) => d.id === boundaryType);
+        }
         return selected;
       });
     },

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -59,7 +59,10 @@
   let LearnMoreModal;
 
   let bookmark = "";
-  let shareLinkWarning = "";
+  $: shareLinkWarning =
+    $boundary.id === "custom"
+      ? "Cannot create a share link for custom boundaries."
+      : "";
 
   let learnMoreProps = {};
   let chartDescription = `<p>The colored lines on this visualization represent 
@@ -97,9 +100,6 @@
   }
 
   async function loadShare() {
-    // TODO: after the custom boundary upload feature is implemented / fixed,
-    // set ShareLink's `errorMsg` prop when $boundary.id === "custom" as
-    // custom boundaries don't get encoded in the URL query params.
     bookmark = serialize({
       climvar: $climvarStore,
       scenario: $scenarioStore,

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -355,6 +355,7 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
+  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/annual-averages/_ExploreData.svelte
+++ b/src/routes/tools/annual-averages/_ExploreData.svelte
@@ -158,20 +158,12 @@
     climvarStore.set(e.detail.id);
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      // FIXME: this prevents the ShareLink from preventing a shareable URL
-      // because the boundary id will never be "custom" when a user clicks the
-      // share button.
-      // NOTE: custom boundary upload was removed in #236 so currenty this code
-      // does nothing. When re-implementing the custom boundary upload, this
-      // should be fixed.
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 </script>
 

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -214,20 +214,12 @@
     indicatorsStore.set(e.detail);
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      // FIXME: this prevents the ShareLink from preventing a shareable URL
-      // because the boundary id will never be "custom" when a user clicks the
-      // share button.
-      // NOTE: custom boundary upload was removed in #236 so currenty this code
-      // does nothing. When re-implementing the custom boundary upload, this
-      // should be fixed.
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 
   function changeThreshold(e) {

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -467,6 +467,7 @@
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"
+  enableUpload="{false}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/degree-days/_ExploreData.svelte
+++ b/src/routes/tools/degree-days/_ExploreData.svelte
@@ -77,7 +77,6 @@
   let LearnMoreModal;
 
   let bookmark = "";
-  let shareLinkWarning = "";
 
   let learnMoreProps = {};
   let chartDescription = `<p>The colored lines on this visualization represent 
@@ -142,21 +141,17 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      bookmark = serialize({
-        climvar: $climvarStore,
-        frequency: $frequencyStore,
-        indicator: $indicatorsStore,
-        scenario: $scenarioStore,
-        threshold: $thresholdStore,
-        models: $modelsStore.join(","),
-        months: $selectedMonthsStore,
-        fid: $location.id,
-        boundary: $boundary.id,
-      });
-    }
+    bookmark = serialize({
+      climvar: $climvarStore,
+      frequency: $frequencyStore,
+      indicator: $indicatorsStore,
+      scenario: $scenarioStore,
+      threshold: $thresholdStore,
+      models: $modelsStore.join(","),
+      months: $selectedMonthsStore,
+      fid: $location.id,
+      boundary: $boundary.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;
@@ -450,7 +445,6 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
-  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -229,6 +229,7 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
+  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -53,7 +53,10 @@
   let LearnMoreModal;
 
   let bookmark = "";
-  let shareLinkWarning = "";
+  $: shareLinkWarning =
+    $boundary.id === "custom"
+      ? "Cannot create a share link for custom boundaries."
+      : "";
 
   let learnMoreProps = {};
 
@@ -97,17 +100,13 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        period: $periodStore,
-        fid: $location.id,
-        boundary: $boundary.id,
-      });
-    }
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      period: $periodStore,
+      fid: $location.id,
+      boundary: $boundary.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;

--- a/src/routes/tools/extended-drought/_ExploreData.svelte
+++ b/src/routes/tools/extended-drought/_ExploreData.svelte
@@ -138,20 +138,12 @@
     ).default;
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      // FIXME: this prevents the ShareLink from preventing a shareable URL
-      // because the boundary id will never be "custom" when a user clicks the
-      // share button.
-      // NOTE: custom boundary upload was removed in #236 so currenty this code
-      // does nothing. When re-implementing the custom boundary upload, this
-      // should be fixed.
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 </script>
 

--- a/src/routes/tools/extended-drought/_data.js
+++ b/src/routes/tools/extended-drought/_data.js
@@ -3,12 +3,7 @@ import { merge } from "d3-array";
 
 // Helpers
 import config from "~/helpers/api-config";
-import {
-  handleXHR,
-  fetchData,
-  transformResponse,
-  isLeapYear,
-} from "~/helpers/utilities";
+import { handleXHR, fetchData, transformResponse } from "~/helpers/utilities";
 import {
   OBSERVED,
   OBSERVED_FILTER_YEAR,
@@ -119,7 +114,7 @@ const fetchEvents = async ({ slug, params, method = "GET" }) => {
 const fetchSeries = async ({ series, params, method = "GET", isRate }) => {
   try {
     const { slugs } = series;
-    const promises = slugs.map((slug) => fetchEvents({ slug, params }));
+    const promises = slugs.map((slug) => fetchEvents({ slug, params, method }));
     const responses = await Promise.all(promises);
     const mergedResponses = merge(responses);
     const values = mergedResponses.map((d) => {

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -178,14 +178,12 @@
     ).default;
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 </script>
 

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -55,7 +55,6 @@
   let LearnMoreModal;
 
   let bookmark = "";
-  let shareLinkWarning = "";
 
   let learnMoreProps = {};
   let metadata;
@@ -115,18 +114,14 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      // TODO: add threshold value?
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        models: $modelsStore.join(","),
-        boundary: $boundary.id,
-        fid: $location.id,
-      });
-    }
+    // TODO: add threshold value?
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      models: $modelsStore.join(","),
+      boundary: $boundary.id,
+      fid: $location.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;
@@ -252,7 +247,6 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
-  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extreme-heat/_ExploreData.svelte
+++ b/src/routes/tools/extreme-heat/_ExploreData.svelte
@@ -260,6 +260,7 @@
 <svelte:component
   this="{ChangeLocation}"
   bind:open="{showChangeLocation}"
+  enableUpload="{false}"
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -225,20 +225,12 @@
     ).default;
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      // FIXME: this prevents the ShareLink from preventing a shareable URL
-      // because the boundary id will never be "custom" when a user clicks the
-      // share button.
-      // NOTE: custom boundary upload was removed in #236 so currenty this code
-      // does nothing. When re-implementing the custom boundary upload, this
-      // should be fixed.
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 </script>
 

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -63,7 +63,6 @@
   let LearnMoreModal;
 
   let bookmark = "";
-  let shareLinkWarning = "";
 
   let learnMoreProps = {};
   let metadata;
@@ -145,24 +144,20 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        duration: $durationStore,
-        /* BUG: when these values are loaded on initApp in index.svelte, the
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      duration: $durationStore,
+      /* BUG: when these values are loaded on initApp in index.svelte, the
            data fetching breaks.
         */
-        // threshType: $thresholdTypeStore,
-        // indicator: $indicator.id,
-        // aggregation: $aggregateFnStore,
-        models: $modelsStore.join(","),
-        boundary: $boundary.id,
-        fid: $location.id,
-      });
-    }
+      // threshType: $thresholdTypeStore,
+      // indicator: $indicator.id,
+      // aggregation: $aggregateFnStore,
+      models: $modelsStore.join(","),
+      boundary: $boundary.id,
+      fid: $location.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;
@@ -306,7 +301,6 @@
   this="{ShareLink}"
   bind:open="{showShare}"
   state="{bookmark}"
-  errorMsg="{shareLinkWarning}"
 />
 
 <svelte:component

--- a/src/routes/tools/extreme-precipitation/_ExploreData.svelte
+++ b/src/routes/tools/extreme-precipitation/_ExploreData.svelte
@@ -320,6 +320,7 @@
 <svelte:component
   this="{ChangeLocation}"
   bind:open="{showChangeLocation}"
+  enableUpload="{false}"
   location="{$location}"
   boundary="{$boundary}"
   boundaryList="{SMALL_SCALE_BOUNDARIES}"

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -319,6 +319,7 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
+  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -64,7 +64,10 @@
   let timeSlider;
 
   let bookmark = "";
-  let shareLinkWarning = "";
+  $: shareLinkWarning =
+    $boundary.id === "custom"
+      ? "Cannot create a share link for custom boundaries."
+      : "";
 
   let learnMoreProps = {};
 
@@ -123,21 +126,17 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        models: $modelsStore.join(","),
-        modelSingle: $modelSingleStore,
-        year: $yearStore,
-        month: $monthStore,
-        duration: $durationStore,
-        boundary: $boundary.id,
-        fid: $location.id,
-      });
-    }
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      models: $modelsStore.join(","),
+      modelSingle: $modelSingleStore,
+      year: $yearStore,
+      month: $monthStore,
+      duration: $durationStore,
+      boundary: $boundary.id,
+      fid: $location.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;

--- a/src/routes/tools/snowpack/_ExploreData.svelte
+++ b/src/routes/tools/snowpack/_ExploreData.svelte
@@ -172,20 +172,12 @@
     activeTab = event.detail;
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      // FIXME: this prevents the ShareLink from preventing a shareable URL
-      // because the boundary id will never be "custom" when a user clicks the
-      // share button.
-      // NOTE: custom boundary upload was removed in #236 so currenty this code
-      // does nothing. When re-implementing the custom boundary upload, this
-      // should be fixed.
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 
   function handleSliderChange(e) {

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -188,14 +188,12 @@
     activeTab = event.detail;
   }
 
-  function changeLocation(e) {
-    if (e.detail.boundaryId === "custom") {
-      locationStore.updateBoundary("locagrid");
-      locationStore.updateLocation(e.detail.location, true);
-    } else {
-      locationStore.updateBoundary(e.detail.boundaryId);
-      locationStore.updateLocation(e.detail.location);
-    }
+  function changeLocation({ detail: { location, boundaryId } }) {
+    locationStore.updateAll({
+      location,
+      boundaryId,
+      isUpload: boundaryId === "custom",
+    });
   }
 
   function handleSliderChange(e) {

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -341,6 +341,7 @@
   boundary="{$boundary}"
   boundaryList="{DEFAULT_BOUNDARIES}"
   addStateBoundary="{true}"
+  enableUpload="{true}"
   on:change="{changeLocation}"
 />
 

--- a/src/routes/tools/wildfire/_ExploreData.svelte
+++ b/src/routes/tools/wildfire/_ExploreData.svelte
@@ -72,7 +72,6 @@
   let timeSlider;
 
   let bookmark = "";
-  let shareLinkWarning = "";
 
   let learnMoreProps = {};
 
@@ -86,6 +85,11 @@
   let activeTab = 0;
   $: activeTab, mapboxMap && mapboxMap.resize();
   $: activeTab, timeSlider && timeSlider.cancelAnimation();
+
+  $: shareLinkWarning =
+    $boundary.id === "custom"
+      ? "Cannot create a share link for custom boundaries."
+      : "";
 
   $: formatFn = format(`.${$climvar.decimals}f`);
 
@@ -139,21 +143,17 @@
   }
 
   async function loadShare() {
-    if ($boundary.id === "custom") {
-      shareLinkWarning = "Cannot create a share link for a custom boundary";
-    } else {
-      bookmark = serialize({
-        climvar: $climvarStore,
-        scenario: $scenarioStore,
-        models: $modelsStore.join(","),
-        modelSingle: $modelSingleStore,
-        year: $yearStore,
-        month: $monthStore,
-        simulation: $simulationStore,
-        boundary: $boundary.id,
-        fid: $location.id,
-      });
-    }
+    bookmark = serialize({
+      climvar: $climvarStore,
+      scenario: $scenarioStore,
+      models: $modelsStore.join(","),
+      modelSingle: $modelSingleStore,
+      year: $yearStore,
+      month: $monthStore,
+      simulation: $simulationStore,
+      boundary: $boundary.id,
+      fid: $location.id,
+    });
     showShare = true;
     ShareLink = (await import("~/components/tools/Partials/ShareLink.svelte"))
       .default;

--- a/src/routes/tools/wildfire/_constants.js
+++ b/src/routes/tools/wildfire/_constants.js
@@ -18,6 +18,7 @@ export const DEFAULT_INITIAL_CONFIG = {
   climvar: DEFAULT_CLIMVAR,
   lng: DEFAULT_CENTER[0],
   lat: DEFAULT_CENTER[1],
+  fid: 41258,
   imperial: false,
 };
 


### PR DESCRIPTION
Fixes a bug in all tools that accept a custom boundary upload in their Change Location widget. Ensures that POST requests are made to the Cal-Adapt API endpoint when the boundary type is "custom" so that data is aggregated for all LOCA grid cells that intersect the custom boundary's geometry.

Tools to check that have the custom boundary upload option:
- [x] Annual Averages
- [x] Extended Drought
- [x] Snow Pack
- [x] Wildfire 

Misc:
- [x] clicking the Share Link button should display a warning when a custom boundary is being used and not display a URL to copy.