### PR TITLE
Fix typo in Extreme Events popup in Extreme Weather tool

### DIFF
--- a/src/routes/tools/extreme-weather/_constants.js
+++ b/src/routes/tools/extreme-weather/_constants.js
@@ -92,7 +92,7 @@ export const EXTREME_EVENT_DESCRIPTION = `<p>According to WMO
 	<ul style="padding-left:1.5rem;">
 	<li><strong>Extreme</strong>: Exceedance Probability <= 1%</li>
 	<li><strong>Rare</strong>: Exceedance Probability > 1% and < 25%</li>
-	<li><strong>Common</strong>: Exceedance Probability <= 25%</li>
+	<li><strong>Common</strong>: Exceedance Probability >= 25%</li>
 	</ul>`;
 
 export const PROPBABILITY_DESCRIPTION = `<p>The Exceedance Probability describes the 


### PR DESCRIPTION
This PR fixes a typo in the Extreme Events popup of the Extreme Weather tool.

Error: Exceedance Probability <= 25%
Fixed to: Exceedance Probability >= 25%