### PR TITLE
Remove beta from title of SLR-CIS tool

### DIFF
--- a/src/routes/tools/slr-coastal-inundation/index.svelte
+++ b/src/routes/tools/slr-coastal-inundation/index.svelte
@@ -197,7 +197,7 @@
 
 <Header
   iconPaths="{tool.icons}"
-  title="{`${tool.title} (beta)`}"
+  title="{tool.title}"
   description="{description}"
 />
 


### PR DESCRIPTION
This PR removes (beta) from the title of the SLR-CIS tool.