### PR TITLE
Add info static files dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 /src/node_modules/@sapper/
 /__sapper__/
 /static/g/
+/static/files/
 .eslintcache
 
 # Local Netlify folder

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ If you have static files you do not want to cache, you should exclude them from 
 
 Static files are served using [sirv](https://github.com/lukeed/sirv).
 
+### files
+
+The `files` directory is used to host pdfs, Word docs or other files that CEC wants Cal-Adapt to host and are typically not accessible elsewhere on the web. This directory which would normally be in the `static` directory (similar to the `static/img` or `static/data`) is not checked into this github repo.
+
+Files that need to be hosted are directly copied to the Cal-Adapt server at `/var/www/cal-adapt.org/files`. These files can be linked on blogs/events/other content pages as needed e.g. `/files/01_Memo_Evaluation of Downscaled GCMs Using WRF_CEC_final.pdf`.
+
 ## Bundler configuration
 
 Webpack is used to provide code-splitting and dynamic imports, as well as compiling Svelte components.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Static files are served using [sirv](https://github.com/lukeed/sirv).
 
 The `files` directory is used to host pdfs, Word docs or other files that CEC wants Cal-Adapt to host and are typically not accessible elsewhere on the web. This directory which would normally be in the `static` directory (similar to the `static/img` or `static/data`) is not checked into this github repo.
 
-Files that need to be hosted are directly copied to the Cal-Adapt server at `/var/www/cal-adapt.org/files`. These files can be linked on blogs/events/other content pages as needed e.g. `/files/01_Memo_Evaluation of Downscaled GCMs Using WRF_CEC_final.pdf`.
+Files that need to be hosted are directly copied to the Cal-Adapt server at `/var/www/cal-adapt.org/files`. These files can be linked on blogs/events/other content pages as needed e.g. `/files/01_Memo_Evaluation_of_Downscaled_GCMs_Using_WRF_CEC_final.pdf`. **Note:** Filenames should not have blank spaces.
 
 ## Bundler configuration
 

--- a/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
+++ b/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
@@ -59,7 +59,7 @@ Feel free to send any questions regarding the Cal-Adapt Workshop to <nethomas@be
 
 <h2 id="materials">Workshop Materials</h2>
 Thank you to all the participants for the extremely helpful feedback! Here are the materials from the workshop:
-* Presentation - <a href="/docs/gif-opr-energy-sector-workshop-materials/Final_Cal_Adapt2.0.pdf" target="_blank">Introduction</a>
-* Presentation - <a href="/docs/gif-opr-energy-sector-workshop-materials/wilhelm_energy_sector_examples_091217.pdf" target="_blank">Examples of How Energy Sector Resilience Efforts Have Used Cal-Adapt</a>
+* Presentation - <a href="/files/gif-opr-energy-sector-workshop-materials/Final_Cal_Adapt2.0.pdf" target="_blank">Introduction</a>
+* Presentation - <a href="/files/gif-opr-energy-sector-workshop-materials/wilhelm_energy_sector_examples_091217.pdf" target="_blank">Examples of How Energy Sector Resilience Efforts Have Used Cal-Adapt</a>
 * Presentation - <a href="https://youtu.be/XhaLdjRn2sk" target="_blank">Video</a>
-* Breakout Sessions - <a href="/docs/gif-opr-energy-sector-workshop-materials/Break_out Notes.docx" target="_blank">Notes</a>
+* Breakout Sessions - <a href="/files/gif-opr-energy-sector-workshop-materials/Break_out Notes.docx" target="_blank">Notes</a>

--- a/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
+++ b/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
@@ -8,7 +8,7 @@ image: Sacramento_Skyline.png
 teaser: New features and capabilities of Cal-Adapt v2.0 by UC Berkeley’s Geospatial Innovation Facility and an overview of the State Adaptation Clearinghouse by the Governor’s Office of Planning and Research.
 ---
 
-<u><a href="#materials">LINKS TO WORKSHOP MATERIALS</a></u><br/>
+<u><a href="/events/gif-opr-energy-sector-workshops/#materials">LINKS TO WORKSHOP MATERIALS</a></u><br/>
 
 UC Berkeley’s <a href="http://gif.berkeley.edu/" target="_blank">Geospatial Innovation Facility</a> (GIF) and the <a href="https://www.opr.ca.gov/" target="_blank">Governor’s Office of Planning and Research</a> (OPR) are pleased to invite you to a duo of energy sector-focused workshops for eliciting needs related to climate adaptation on September 12 in Sacramento at the California Energy Commission (Imbrecht Hearing Room). The day will include two user-focused workshops:
 * Morning session (9:30 AM to noon) on Cal-Adapt 2.0

--- a/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
+++ b/content/events/2017-08-31-gif-opr-energy-sector-workshops.md
@@ -62,4 +62,4 @@ Thank you to all the participants for the extremely helpful feedback! Here are t
 * Presentation - <a href="/files/gif-opr-energy-sector-workshop-materials/Final_Cal_Adapt2.0.pdf" target="_blank">Introduction</a>
 * Presentation - <a href="/files/gif-opr-energy-sector-workshop-materials/wilhelm_energy_sector_examples_091217.pdf" target="_blank">Examples of How Energy Sector Resilience Efforts Have Used Cal-Adapt</a>
 * Presentation - <a href="https://youtu.be/XhaLdjRn2sk" target="_blank">Video</a>
-* Breakout Sessions - <a href="/files/gif-opr-energy-sector-workshop-materials/Break_out Notes.docx" target="_blank">Notes</a>
+* Breakout Sessions - <a href="/files/gif-opr-energy-sector-workshop-materials/Break_out_Notes.docx" target="_blank">Notes</a>

--- a/content/grants/research.js
+++ b/content/grants/research.js
@@ -11,7 +11,7 @@ export default [
     type: `Research Memo`,
     number: "EPC-20-006",
     title: "2022 - Nov: Memorandum on the Evaluation of Dynamically Downscaled GCMs Using WRF",
-    url: "/files/01_Memo_Evaluation_of_Downscaled_GCMs_Using_WRF_CEC_final.pdf"
+    url: "https://www.energy.ca.gov/sites/default/files/2022-09/20220907_CDAWG_MemoDynamicalDownscaling_EPC-20-006_May2022-ADA.pdf"
   },
   {
     agency: "California Energy Commission",

--- a/content/grants/research.js
+++ b/content/grants/research.js
@@ -11,7 +11,7 @@ export default [
     type: `Research Memo`,
     number: "EPC-20-006",
     title: "2022 - Nov: Memorandum on the Evaluation of Dynamically Downscaled GCMs Using WRF",
-    url: "https://www.energy.ca.gov/sites/default/files/2022-09/20220907_CDAWG_MemoDynamicalDownscaling_EPC-20-006_May2022-ADA.pdfs"
+    url: "/files/01_Memo_Evaluation_of_Downscaled_GCMs_Using_WRF_CEC_final.pdf"
   },
   {
     agency: "California Energy Commission",

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -235,7 +235,7 @@
       <div class="bx--row">
         <div class="bx--col-lg-12">
           <h3>
-            Discover how our <a href="/grants" target="_blank"
+            Discover how our <a href="/grants"
               >data development grants and research projects</a
             >
             are helping to shape the next generation of Cal-Adapt


### PR DESCRIPTION
This PR describes a new static `files` dir on the server that is used to host word documents, pdf files, etc. (any file resource that CEC wants us to host), but is not tracked in the github repo.